### PR TITLE
Implement OpenAI-backed preflight gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@
 - PR: TBD — added pipeline-specific directory input overrides, chunked directory
   aggregation, CLI integration coverage, and a smoke-test runbook for manual
   verification.
+- Documented the preflight extraction/query planning workflow, including CLI
+  quickstart examples and JSON schema references for generated artefacts.

--- a/README.md
+++ b/README.md
@@ -479,6 +479,42 @@ python run_critique.py sample_content.txt --scientific --PR
 python src/syncretic_catalyst/thesis_builder.py "Quantum computation applied to climate modeling"
 ```
 
+### Preflight Extraction & Query Planning
+
+The critique runner ships with a preflight stage that can summarise source
+material into structured JSON artefacts **before** the main critique. Use it to
+seed downstream review workflows or to inspect the extracted context manually.
+
+1. Ensure your `config.json` includes the preflight defaults added in this
+   release (they ship enabled but disabled by default when provider settings are
+   missing).
+2. Run extraction on a document while customising the artefact path:
+
+   ```bash
+   python run_critique.py sample_content.txt \
+       --preflight-extract \
+       --points-out artifacts/example_points.json
+   ```
+
+   This produces `artifacts/example_points.json` aligned with
+   `src/contexts/schemas/extraction.schema.json`.
+3. Build a query plan in the same pass by enabling both stages and setting
+   explicit caps (they fall back to configuration defaults when omitted):
+
+   ```bash
+   python run_critique.py sample_content.txt \
+       --preflight-extract \
+       --preflight-build-queries \
+       --max-points 8 \
+       --max-queries 5 \
+       --points-out artifacts/example_points.json \
+       --queries-out artifacts/example_queries.json
+   ```
+
+   The CLI persists both artefacts and updates run metadata so downstream steps
+   can discover them automatically. The resulting files validate against the
+   schemas documented in `docs/preflight_json_schemas.md`.
+
 ## Learn More
 
 - [Documentation](docs/)

--- a/config.json
+++ b/config.json
@@ -20,6 +20,29 @@
       "max_tokens": 30000
     }
   },
+  "preflight": {
+    "provider": "openai",
+    "metadata": {
+      "stage": "preflight"
+    },
+    "extract": {
+      "enabled": false,
+      "max_points": 12,
+      "artifact_path": "artifacts/points.json"
+    },
+    "queries": {
+      "enabled": false,
+      "max_queries": 8,
+      "artifact_path": "artifacts/queries.json"
+    },
+    "api": {
+      "openai": {
+        "model": "gpt-4.1-mini",
+        "temperature": 0.2,
+        "max_tokens": 8192
+      }
+    }
+  },
   "reasoning_tree": {
     "max_depth": 1,
     "confidence_threshold": 0.3

--- a/docs/preflight_json_schemas.md
+++ b/docs/preflight_json_schemas.md
@@ -1,0 +1,108 @@
+# Preflight JSON Schemas
+
+Cogito's preflight pipeline writes structured JSON artefacts that downstream
+tools can consume without invoking the critique workflow. The schemas live under
+`src/contexts/schemas/` and mirror the immutable domain models defined in
+`src/domain/preflight/models.py`.
+
+## Extraction Result (`extraction.schema.json`)
+
+An extraction run returns an `ExtractionResult` document with the following
+shape:
+
+- `points` *(array, required)* – ordered list of extracted insights. Each entry
+  must satisfy the `ExtractedPoint` definition:
+  - `id` *(string, required)* – stable identifier (`pt-<n>` by convention).
+  - `title` *(string, required)* – concise heading.
+  - `summary` *(string, required)* – multi-sentence description.
+  - `evidence_refs` *(array[string], required)* – supporting references such as
+    file paths or citation identifiers.
+  - `confidence` *(number, required)* – normalised confidence within `[0.0, 1.0]`.
+  - `tags` *(array[string], optional)* – thematic classifications. Defaults to
+    an empty list when omitted.
+- `source_stats` *(object, required)* – metadata describing the analysed corpus
+  (counts, token usage, truncation flags). Additional keys are permitted so the
+  orchestrator can surface provider-specific measurements without breaking
+  consumers.
+- `truncated` *(boolean, required)* – signals that caps or provider limits
+  prevented the extractor from emitting the full set of points.
+
+### Example Extraction Artefact
+
+```json
+{
+  "points": [
+    {
+      "id": "pt-1",
+      "title": "Transformer depth controls summarisation fidelity",
+      "summary": "Long-form transcripts benefit from deeper decoder stacks...",
+      "evidence_refs": ["/docs/transcript.md#L42-L88"],
+      "confidence": 0.82,
+      "tags": ["summarisation", "architecture"]
+    }
+  ],
+  "source_stats": {
+    "source_count": 1,
+    "char_count": 18450,
+    "time_ms": 2940
+  },
+  "truncated": false
+}
+```
+
+## Query Plan (`query_plan.schema.json`)
+
+Query planning yields a `QueryPlan` document comprised of:
+
+- `queries` *(array, required)* – ordered list of follow-up actions. Each entry
+  adheres to the `BuiltQuery` definition:
+  - `id` *(string, required)* – stable identifier (`q-<n>` by convention).
+  - `text` *(string, required)* – natural-language request.
+  - `purpose` *(string, required)* – why the query matters.
+  - `priority` *(integer, required)* – execution order; lower numbers run first.
+  - `depends_on_ids` *(array[string], optional)* – prerequisites that must
+    complete successfully.
+  - `target_audience` *(string|null, optional)* – intended respondent or system.
+  - `suggested_tooling` *(array[string], optional)* – helper tools or pipelines.
+- `rationale` *(string, required)* – overall strategy for the plan. Defaults to
+  an empty string when omitted by the model but is filled during parsing.
+- `assumptions` *(array[string], optional)* – contextual assumptions for the
+  plan (default: empty list).
+- `risks` *(array[string], optional)* – identified risks or mitigations
+  (default: empty list).
+
+### Example Query Plan Artefact
+
+```json
+{
+  "queries": [
+    {
+      "id": "q-1",
+      "text": "Request the original dataset to verify reported baselines.",
+      "purpose": "Validate reproducibility claims before deeper analysis.",
+      "priority": 1,
+      "depends_on_ids": [],
+      "target_audience": "research-author",
+      "suggested_tooling": ["http_client"]
+    }
+  ],
+  "rationale": "Confirm data availability before designing experiments.",
+  "assumptions": ["Authors can share the dataset"],
+  "risks": ["Dataset may be proprietary"]
+}
+```
+
+## Validation & Tooling
+
+- Integration coverage lives in
+  `tests/integration/test_cli_preflight_artifacts.py` and verifies the CLI emits
+  artefacts that conform to both schemas.
+- Run the test directly to validate local changes:
+
+  ```bash
+  pytest tests/integration/test_cli_preflight_artifacts.py -q
+  ```
+- For ad-hoc inspection, pass generated artefacts through any JSON Schema
+  validator that supports Draft 2020-12 (for example the `jsonschema` Python
+  package).
+

--- a/enhancement_directory_input.md
+++ b/enhancement_directory_input.md
@@ -37,9 +37,9 @@ Instruction to Coding Agent: Use this checklist to create concrete tasks and imp
 
 ## 4) Application Wiring
 
-- [ ] Add services:
-  - [ ] `ExtractionService.run(PipelineInput) -> ExtractionResult`.
-  - [ ] `QueryBuildingService.run(ExtractionResult, PipelineInput?) -> QueryPlan`.
+- [x] Add services:
+  - [x] `ExtractionService.run(PipelineInput) -> ExtractionResult`.
+  - [x] `QueryBuildingService.run(ExtractionResult, PipelineInput?) -> QueryPlan`.
 - [ ] Update orchestrator(s) (optional toggle):
   - [ ] New preflight stage: run extraction → queries before critique, or write artifacts for later stages.
   - [ ] Record outputs to artifacts directory (JSON files) and attach paths to run metadata.

--- a/enhancement_directory_input.md
+++ b/enhancement_directory_input.md
@@ -63,17 +63,17 @@ Instruction to Coding Agent: Use this checklist to create concrete tasks and imp
 
 ## 7) Logging, Metrics, and Observability
 
-- [ ] Structured logs (no content):
-  - [ ] Extraction summary: points_count, truncated, time_ms.
-  - [ ] Query plan summary: queries_count, dependencies_present, time_ms.
-  - [ ] Provider context on errors: provider, operation, stage, failure_class, fallback_used.
-- [ ] Emit internal metrics: `time_to_first_token_ms`, `total_duration_ms`, `emitted_count` when streaming is applicable.
+- [x] Structured logs (no content):
+  - [x] Extraction summary: points_count, truncated, time_ms.
+  - [x] Query plan summary: queries_count, dependencies_present, time_ms.
+  - [x] Provider context on errors: provider, operation, stage, failure_class, fallback_used.
+- [x] Emit internal metrics: `time_to_first_token_ms`, `total_duration_ms`, `emitted_count` when streaming is applicable.
 
 ## 8) Error Handling & Timeouts
 
-- [ ] Use shared timeout config and `operation_timeout` wrappers for blocking segments.
-- [ ] Retry policy: single retry on schema-parse failure with corrective system instruction.
-- [ ] Never fail silently; return artifacts with `validation_errors` when strict validation fails.
+- [x] Use shared timeout config and `operation_timeout` wrappers for blocking segments.
+- [x] Retry policy: single retry on schema-parse failure with corrective system instruction.
+- [x] Never fail silently; return artifacts with `validation_errors` when strict validation fails.
 
 ## 9) Security & Privacy
 

--- a/enhancement_directory_input.md
+++ b/enhancement_directory_input.md
@@ -90,20 +90,20 @@ Instruction to Coding Agent: Use this checklist to create concrete tasks and imp
 - [x] Integration tests:
   - [x] CLI with `--preflight-extract` produces `points.json` with valid schema.
   - [x] CLI with `--preflight-build-queries` produces `queries.json` with valid schema.
-- [ ] Edge cases:
-  - [ ] Empty/very small input → zero points, no errors.
-  - [ ] Large input → capped points, `truncated=true` in metadata.
-  - [ ] Provider error → artifact with `fallback_used=true` and error logged once.
-- [ ] Decomposition Output Robustness (array vs object):
-  - [ ] Normalization layer accepts both shapes:
-    - [ ] If result is a list of strings, use directly.
-    - [ ] If result is an object with a list-of-strings under common keys (prefer `topics`, fallback `items`/`subtopics`), extract that list.
-    - [ ] If neither, log a single structured warning per run (provider, model, keys seen, expected) and skip recursion for that branch.
-  - [ ] Prompt alignment:
-    - [ ] Update decomposition prompt to request an object shape: `{ "topics": ["...", "..."] }` to match providers that enforce `json_object` responses when `is_structured=true`.
+- [x] Edge cases:
+  - [x] Empty/very small input → zero points, no errors.
+  - [x] Large input → capped points, `truncated=true` in metadata.
+  - [x] Provider error → artifact with `fallback_used=true` and error logged once.
+- [x] Decomposition Output Robustness (array vs object):
+  - [x] Normalization layer accepts both shapes:
+    - [x] If result is a list of strings, use directly.
+    - [x] If result is an object with a list-of-strings under common keys (prefer `topics`, fallback `items`/`subtopics`), extract that list.
+    - [x] If neither, log a single structured warning per run (provider, model, keys seen, expected) and skip recursion for that branch.
+  - [x] Prompt alignment:
+    - [x] Update decomposition prompt to request an object shape: `{ "topics": ["...", "..."] }` to match providers that enforce `json_object` responses when `is_structured=true`.
     - [ ] Alternatively, for o-series Responses API, prefer `json_schema` with an array-of-strings schema when supported; otherwise keep object-with-topics.
   - [ ] Tests:
-    - [ ] Unit: parser accepts `list[str]` and `{topics: list[str]}`; rejects other shapes with a single warning.
+    - [x] Unit: parser accepts `list[str]` and `{topics: list[str]}`; rejects other shapes with a single warning.
     - [ ] Integration: run with decomposition using `gpt-5` and confirm no repeated warnings; recursion proceeds with extracted topics.
 
 ## 11) Documentation

--- a/enhancement_directory_input.md
+++ b/enhancement_directory_input.md
@@ -108,9 +108,9 @@ Instruction to Coding Agent: Use this checklist to create concrete tasks and imp
 
 ## 11) Documentation
 
-- [ ] README: quickstart for preflight extraction and query building with example commands.
-- [ ] Add short JSON schema docs under `docs/` with sample outputs.
-- [ ] CHANGELOG: note the new preflight stages and artifacts.
+- [x] README: quickstart for preflight extraction and query building with example commands.
+- [x] Add short JSON schema docs under `docs/` with sample outputs.
+- [x] CHANGELOG: note the new preflight stages and artifacts.
 
 ## 12) Performance & Limits
 

--- a/enhancement_directory_input.md
+++ b/enhancement_directory_input.md
@@ -87,9 +87,9 @@ Instruction to Coding Agent: Use this checklist to create concrete tasks and imp
   - [x] Prompt builder emits constraints and exemplars.
   - [x] Parser validates schema and surfaces errors; retry path covered.
   - [x] Services handle caps and truncated inputs.
-- [ ] Integration tests:
-  - [ ] CLI with `--preflight-extract` produces `points.json` with valid schema.
-  - [ ] CLI with `--preflight-build-queries` produces `queries.json` with valid schema.
+- [x] Integration tests:
+  - [x] CLI with `--preflight-extract` produces `points.json` with valid schema.
+  - [x] CLI with `--preflight-build-queries` produces `queries.json` with valid schema.
 - [ ] Edge cases:
   - [ ] Empty/very small input → zero points, no errors.
   - [ ] Large input → capped points, `truncated=true` in metadata.

--- a/enhancement_directory_input.md
+++ b/enhancement_directory_input.md
@@ -4,36 +4,36 @@ Instruction to Coding Agent: Use this checklist to create concrete tasks and imp
 
 ## 1) Architecture & Contracts
 
-- [ ] Define clean contracts in the application layer (no framework deps):
-  - [ ] `PointExtractorGateway` (port): extract concise, structured points from raw `PipelineInput`.
-  - [ ] `QueryBuilderGateway` (port): produce follow-up questions/queries from points and context.
-  - [ ] `ExtractionService` and `QueryBuildingService` orchestration services (thin, pure, testable).
-- [ ] DTOs (domain/application):
-  - [ ] `ExtractedPoint` (id, title, summary, evidence_refs, confidence [0-1], tags[]).
-  - [ ] `ExtractionResult` (points[], source_stats, truncated: bool).
-  - [ ] `BuiltQuery` (id, text, purpose, priority, depends_on_ids[], target_audience, suggested_tooling?).
-  - [ ] `QueryPlan` (queries[], rationale, assumptions, risks).
-- [ ] Ensure dependency direction: presentation → application → providers/infrastructure (inward only).
+- [x] Define clean contracts in the application layer (no framework deps):
+  - [x] `PointExtractorGateway` (port): extract concise, structured points from raw `PipelineInput`.
+  - [x] `QueryBuilderGateway` (port): produce follow-up questions/queries from points and context.
+  - [x] `ExtractionService` and `QueryBuildingService` orchestration services (thin, pure, testable).
+- [x] DTOs (domain/application):
+  - [x] `ExtractedPoint` (id, title, summary, evidence_refs, confidence [0-1], tags[]).
+  - [x] `ExtractionResult` (points[], source_stats, truncated: bool).
+  - [x] `BuiltQuery` (id, text, purpose, priority, depends_on_ids[], target_audience, suggested_tooling?).
+  - [x] `QueryPlan` (queries[], rationale, assumptions, risks).
+- [x] Ensure dependency direction: presentation → application → providers/infrastructure (inward only).
 
 ## 2) Prompting & Structured Output
 
-- [ ] Author robust LLM prompts (system + user) for:
-  - [ ] Point extraction: require strict JSON output matching a JSON Schema.
-  - [ ] Query building: produce questions/queries with purpose and dependency fields.
-- [ ] Define JSON Schemas (in `src/contexts/schemas/`):
-  - [ ] `extraction.schema.json` for `ExtractionResult`.
-  - [ ] `query_plan.schema.json` for `QueryPlan`.
-- [ ] Implement parser/validator:
-  - [ ] Strict JSON parsing with schema validation; reject if invalid and attempt 1 retry with error message reflection.
-  - [ ] Safe fallbacks: if still invalid, store raw text with `validation_errors` metadata and continue.
+- [x] Author robust LLM prompts (system + user) for:
+  - [x] Point extraction: require strict JSON output matching a JSON Schema.
+  - [x] Query building: produce questions/queries with purpose and dependency fields.
+- [x] Define JSON Schemas (in `src/contexts/schemas/`):
+  - [x] `extraction.schema.json` for `ExtractionResult`.
+  - [x] `query_plan.schema.json` for `QueryPlan`.
+- [x] Implement parser/validator:
+  - [x] Strict JSON parsing with schema validation; reject if invalid and attempt 1 retry with error message reflection.
+  - [x] Safe fallbacks: if still invalid, store raw text with `validation_errors` metadata and continue.
 
 ## 3) Provider Integrations
 
-- [ ] Implement provider adapters behind gateways (e.g., OpenAI first):
-  - [ ] Route GPT‑5/4.1/o‑series through Responses API with `max_output_tokens`.
-  - [ ] Set deterministic defaults (e.g., `temperature=0.2`) unless model requires override.
-  - [ ] Enforce timeouts via shared timeout config; no hard-coded numeric literals.
-- [ ] Add thin mappers: DTO ↔ provider payloads; keep providers isolated from application types.
+- [x] Implement provider adapters behind gateways (e.g., OpenAI first):
+  - [x] Route GPT‑5/4.1/o‑series through Responses API with `max_output_tokens`.
+  - [x] Set deterministic defaults (e.g., `temperature=0.2`) unless model requires override.
+  - [x] Enforce timeouts via shared timeout config; no hard-coded numeric literals.
+- [x] Add thin mappers: DTO ↔ provider payloads; keep providers isolated from application types.
 
 ## 4) Application Wiring
 

--- a/enhancement_directory_input.md
+++ b/enhancement_directory_input.md
@@ -83,10 +83,10 @@ Instruction to Coding Agent: Use this checklist to create concrete tasks and imp
 
 ## 10) Tests (TDD preferred)
 
-- [ ] Unit tests:
-  - [ ] Prompt builder emits constraints and exemplars.
-  - [ ] Parser validates schema and surfaces errors; retry path covered.
-  - [ ] Services handle caps and truncated inputs.
+- [x] Unit tests:
+  - [x] Prompt builder emits constraints and exemplars.
+  - [x] Parser validates schema and surfaces errors; retry path covered.
+  - [x] Services handle caps and truncated inputs.
 - [ ] Integration tests:
   - [ ] CLI with `--preflight-extract` produces `points.json` with valid schema.
   - [ ] CLI with `--preflight-build-queries` produces `queries.json` with valid schema.

--- a/enhancement_directory_input.md
+++ b/enhancement_directory_input.md
@@ -40,9 +40,9 @@ Instruction to Coding Agent: Use this checklist to create concrete tasks and imp
 - [x] Add services:
   - [x] `ExtractionService.run(PipelineInput) -> ExtractionResult`.
   - [x] `QueryBuildingService.run(ExtractionResult, PipelineInput?) -> QueryPlan`.
-- [ ] Update orchestrator(s) (optional toggle):
-  - [ ] New preflight stage: run extraction → queries before critique, or write artifacts for later stages.
-  - [ ] Record outputs to artifacts directory (JSON files) and attach paths to run metadata.
+- [x] Update orchestrator(s) (optional toggle):
+  - [x] New preflight stage: run extraction → queries before critique, or write artifacts for later stages.
+  - [x] Record outputs to artifacts directory (JSON files) and attach paths to run metadata.
 
 ## 5) CLI / UX
 

--- a/enhancement_directory_input.md
+++ b/enhancement_directory_input.md
@@ -46,12 +46,12 @@ Instruction to Coding Agent: Use this checklist to create concrete tasks and imp
 
 ## 5) CLI / UX
 
-- [ ] CLI flags in `run_critique.py` (and any relevant entrypoints):
-  - [ ] `--preflight-extract` to enable extraction.
-  - [ ] `--preflight-build-queries` to enable query building.
-  - [ ] `--points-out <path>` and `--queries-out <path>` to control JSON artifact locations.
-  - [ ] `--max-points <n>` and `--max-queries <n>` (caps enforced in prompts and post-filtering).
-- [ ] Help text and examples updated; defaults sourced from `config.json`.
+- [x] CLI flags in `run_critique.py` (and any relevant entrypoints):
+  - [x] `--preflight-extract` to enable extraction.
+  - [x] `--preflight-build-queries` to enable query building.
+  - [x] `--points-out <path>` and `--queries-out <path>` to control JSON artifact locations.
+  - [x] `--max-points <n>` and `--max-queries <n>` (caps enforced in prompts and post-filtering).
+- [x] Help text and examples updated; defaults sourced from `config.json`.
 
 ## 6) Configuration & Defaults
 

--- a/enhancement_directory_input.md
+++ b/enhancement_directory_input.md
@@ -114,12 +114,12 @@ Instruction to Coding Agent: Use this checklist to create concrete tasks and imp
 
 ## 12) Performance & Limits
 
-- [ ] For large inputs, use a bounded chunk → summarize (map) → merge (reduce) pipeline:
-  - [ ] Split content into chunks by semantic boundaries with hard size caps; attach path/offset metadata.
-  - [ ] Run per‑chunk LLM passes (summaries/points) with item caps (e.g., `max_points_per_chunk`).
-  - [ ] Merge and deduplicate across chunks; select top‑K globally by salience/coverage.
-  - [ ] Optional final pass to normalize and fill gaps; keep total tokens within configured budget.
-- [ ] Keep memory bounded (no single giant prompt or whole‑corpus in memory at once); prefer streaming/iterative processing.
+- [x] For large inputs, use a bounded chunk → summarize (map) → merge (reduce) pipeline:
+  - [x] Split content into chunks by semantic boundaries with hard size caps; attach path/offset metadata.
+  - [x] Run per‑chunk LLM passes (summaries/points) with item caps (e.g., `max_points_per_chunk`).
+  - [x] Merge and deduplicate across chunks; select top‑K globally by salience/coverage.
+  - [x] Optional final pass to normalize and fill gaps; keep total tokens within configured budget.
+- [x] Keep memory bounded (no single giant prompt or whole‑corpus in memory at once); prefer streaming/iterative processing.
 
 ## 13) Acceptance Criteria
 

--- a/enhancement_directory_input.md
+++ b/enhancement_directory_input.md
@@ -55,11 +55,11 @@ Instruction to Coding Agent: Use this checklist to create concrete tasks and imp
 
 ## 6) Configuration & Defaults
 
-- [ ] Extend `config.json` with:
-  - [ ] `preflight.extract.enabled`, `preflight.extract.max_points`.
-  - [ ] `preflight.queries.enabled`, `preflight.queries.max_queries`.
-  - [ ] Model + provider settings for preflight stages (model name, temperature, tokens).
-- [ ] Loader changes: keep YAML loader optional; ensure CLI path reads JSON config.
+- [x] Extend `config.json` with:
+  - [x] `preflight.extract.enabled`, `preflight.extract.max_points`.
+  - [x] `preflight.queries.enabled`, `preflight.queries.max_queries`.
+  - [x] Model + provider settings for preflight stages (model name, temperature, tokens).
+- [x] Loader changes: keep YAML loader optional; ensure CLI path reads JSON config.
 
 ## 7) Logging, Metrics, and Observability
 

--- a/enhancement_directory_input.md
+++ b/enhancement_directory_input.md
@@ -101,10 +101,10 @@ Instruction to Coding Agent: Use this checklist to create concrete tasks and imp
     - [x] If neither, log a single structured warning per run (provider, model, keys seen, expected) and skip recursion for that branch.
   - [x] Prompt alignment:
     - [x] Update decomposition prompt to request an object shape: `{ "topics": ["...", "..."] }` to match providers that enforce `json_object` responses when `is_structured=true`.
-    - [ ] Alternatively, for o-series Responses API, prefer `json_schema` with an array-of-strings schema when supported; otherwise keep object-with-topics.
+    - [x] Alternatively, for o-series Responses API, prefer `json_schema` with an array-of-strings schema when supported; otherwise keep object-with-topics.
   - [ ] Tests:
     - [x] Unit: parser accepts `list[str]` and `{topics: list[str]}`; rejects other shapes with a single warning.
-    - [ ] Integration: run with decomposition using `gpt-5` and confirm no repeated warnings; recursion proceeds with extracted topics.
+    - [x] Integration: run with decomposition using `gpt-5` and confirm no repeated warnings; recursion proceeds with extracted topics.
 
 ## 11) Documentation
 

--- a/enhancement_directory_input.md
+++ b/enhancement_directory_input.md
@@ -77,9 +77,9 @@ Instruction to Coding Agent: Use this checklist to create concrete tasks and imp
 
 ## 9) Security & Privacy
 
-- [ ] Do not log content; only counts/ids.
-- [ ] Mask API keys in logs; validate executables via `shutil.which` if any subprocesses are introduced (avoid shell).
-- [ ] Respect max tokens and caps to avoid data overexposure to providers.
+- [x] Do not log content; only counts/ids.
+- [x] Mask API keys in logs; validate executables via `shutil.which` if any subprocesses are introduced (avoid shell).
+- [x] Respect max tokens and caps to avoid data overexposure to providers.
 
 ## 10) Tests (TDD preferred)
 

--- a/src/application/preflight/__init__.py
+++ b/src/application/preflight/__init__.py
@@ -4,6 +4,7 @@ from .ports import PointExtractorGateway, QueryBuilderGateway
 from .prompts import PromptBundle, build_extraction_prompt, build_query_plan_prompt
 from .schemas import load_extraction_schema, load_query_plan_schema
 from .services import ExtractionService, QueryBuildingService
+from .orchestrator import PreflightOptions, PreflightOrchestrator, PreflightRunResult
 from .extraction_parser import ExtractionResponseParser
 from .query_parser import QueryPlanResponseParser
 from .schema_validation import StructuredParseResult, ValidationIssue
@@ -18,6 +19,9 @@ __all__ = [
     "load_query_plan_schema",
     "ExtractionService",
     "QueryBuildingService",
+    "PreflightOptions",
+    "PreflightOrchestrator",
+    "PreflightRunResult",
     "ExtractionResponseParser",
     "QueryPlanResponseParser",
     "StructuredParseResult",

--- a/src/application/preflight/__init__.py
+++ b/src/application/preflight/__init__.py
@@ -1,0 +1,25 @@
+"""Preflight application services and contracts."""
+
+from .ports import PointExtractorGateway, QueryBuilderGateway
+from .prompts import PromptBundle, build_extraction_prompt, build_query_plan_prompt
+from .schemas import load_extraction_schema, load_query_plan_schema
+from .services import ExtractionService, QueryBuildingService
+from .extraction_parser import ExtractionResponseParser
+from .query_parser import QueryPlanResponseParser
+from .schema_validation import StructuredParseResult, ValidationIssue
+
+__all__ = [
+    "PointExtractorGateway",
+    "QueryBuilderGateway",
+    "PromptBundle",
+    "build_extraction_prompt",
+    "build_query_plan_prompt",
+    "load_extraction_schema",
+    "load_query_plan_schema",
+    "ExtractionService",
+    "QueryBuildingService",
+    "ExtractionResponseParser",
+    "QueryPlanResponseParser",
+    "StructuredParseResult",
+    "ValidationIssue",
+]

--- a/src/application/preflight/extraction_parser.py
+++ b/src/application/preflight/extraction_parser.py
@@ -1,0 +1,362 @@
+"""Extraction response parsing utilities for preflight workflows.
+
+Purpose:
+    Validate structured extraction outputs returned by language models and
+    convert them into immutable domain objects. The module encapsulates the
+    validation rules for :class:`~src.domain.preflight.ExtractionResult` so that
+    orchestration services can remain concise.
+External Dependencies:
+    Python standard library modules ``textwrap`` and ``typing`` together with
+    local schema validation helpers.
+Fallback Semantics:
+    The parser reports structured validation issues and, when validation fails,
+    produces fallback artefacts that capture the raw provider response alongside
+    formatted error messages. Callers can persist the fallback output while
+    signalling that schema validation failed.
+Timeout Strategy:
+    Not applicable; all operations are CPU-bound and operate on in-memory data.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+from ...domain.preflight import ExtractedPoint, ExtractionResult
+from .schema_validation import (
+    StructuredParseResult,
+    ValidationIssue,
+    parse_json_payload,
+    reject_additional_keys,
+    require_keys,
+    validate_string_array,
+)
+
+
+def _validate_extracted_point(
+    point: Any,
+    *,
+    index: int,
+    issues: list[ValidationIssue],
+) -> Optional[ExtractedPoint]:
+    """Validate and convert a potential extracted point payload.
+
+    Args:
+        point: Candidate point payload.
+        index: Zero-based index of the point inside the ``points`` array.
+        issues: Mutable list that accumulates validation problems.
+
+    Returns:
+        :class:`ExtractedPoint` when validation succeeds, otherwise ``None``.
+
+    Raises:
+        None. Validation issues are appended to ``issues``.
+
+    Side Effects:
+        Appends :class:`ValidationIssue` entries to ``issues`` when validation
+        fails.
+
+    Timeout:
+        Not applicable; the function processes in-memory data synchronously.
+    """
+
+    path = ("points", str(index))
+    if not isinstance(point, Mapping):
+        issues.append(
+            ValidationIssue(
+                path=path,
+                message="Each point must be an object with the documented properties.",
+            )
+        )
+        return None
+
+    required = ["id", "title", "summary", "evidence_refs", "confidence"]
+    allowed = ["id", "title", "summary", "evidence_refs", "confidence", "tags"]
+    require_keys(point, required, path=path, issues=issues)
+    reject_additional_keys(point, allowed, path=path, issues=issues)
+
+    tags: Tuple[str, ...] = ()
+    if "tags" in point:
+        tags = validate_string_array(point["tags"], path=path + ("tags",), issues=issues)
+
+    evidence_refs: Tuple[str, ...] = ()
+    if "evidence_refs" in point:
+        evidence_refs = validate_string_array(
+            point["evidence_refs"],
+            path=path + ("evidence_refs",),
+            issues=issues,
+            allow_empty=True,
+        )
+
+    confidence_value = point.get("confidence")
+    if isinstance(confidence_value, (int, float)):
+        confidence = float(confidence_value)
+        if not 0.0 <= confidence <= 1.0:
+            issues.append(
+                ValidationIssue(
+                    path=path + ("confidence",),
+                    message="Confidence must be between 0.0 and 1.0.",
+                )
+            )
+    else:
+        issues.append(
+            ValidationIssue(
+                path=path + ("confidence",),
+                message="Confidence must be a numeric value between 0.0 and 1.0.",
+            )
+        )
+        confidence = 0.0
+
+    id_value = point.get("id")
+    title_value = point.get("title")
+    summary_value = point.get("summary")
+    for key, value in ("id", id_value), ("title", title_value), ("summary", summary_value):
+        if not isinstance(value, str) or not value.strip():
+            issues.append(
+                ValidationIssue(
+                    path=path + (key,),
+                    message="Value must be a non-empty string.",
+                )
+            )
+
+    if any(issue.path[:2] == path[:2] for issue in issues):
+        return None
+
+    return ExtractedPoint(
+        id=str(id_value),
+        title=str(title_value),
+        summary=str(summary_value),
+        evidence_refs=evidence_refs,
+        confidence=confidence,
+        tags=tags,
+    )
+
+
+def _format_validation_messages(issues: Sequence[ValidationIssue]) -> Tuple[str, ...]:
+    """Return formatted string representations of validation issues.
+
+    Args:
+        issues: Validation problems raised while parsing model output.
+
+    Returns:
+        Tuple containing human-readable error descriptions. An empty tuple is
+        returned when ``issues`` is empty.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None. The function performs deterministic string formatting.
+
+    Timeout:
+        Not applicable; execution is CPU-bound and synchronous.
+    """
+
+    return tuple(issue.format() for issue in issues)
+
+
+def _build_fallback_result(
+    raw_text: str,
+    issues: Sequence[ValidationIssue],
+) -> ExtractionResult:
+    """Construct a fallback extraction result from invalid structured output.
+
+    Args:
+        raw_text: Original response returned by the language model.
+        issues: Validation problems detected while parsing ``raw_text``.
+
+    Returns:
+        :class:`ExtractionResult` instance containing no structured points but
+        preserving the raw response and formatted validation errors for
+        observability purposes.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None. A new domain object is created based solely on the provided data.
+
+    Timeout:
+        Not applicable; the function operates on in-memory data only.
+    """
+
+    return ExtractionResult(
+        points=(),
+        source_stats={},
+        truncated=False,
+        raw_response=raw_text,
+        validation_errors=_format_validation_messages(issues),
+    )
+
+
+def _validate_extraction_payload(payload: Any) -> Tuple[ValidationIssue, ...]:
+    """Return validation issues for a potential extraction payload."""
+
+    issues: list[ValidationIssue] = []
+    if not isinstance(payload, Mapping):
+        issues.append(
+            ValidationIssue(
+                path=(),
+                message="Root payload must be a JSON object.",
+            )
+        )
+        return tuple(issues)
+
+    required = ["points", "source_stats", "truncated"]
+    allowed = required
+    require_keys(payload, required, path=(), issues=issues)
+    reject_additional_keys(payload, allowed, path=(), issues=issues)
+
+    points_value = payload.get("points")
+    if isinstance(points_value, Sequence) and not isinstance(points_value, (str, bytes)):
+        for index, point in enumerate(points_value):
+            _validate_extracted_point(point, index=index, issues=issues)
+    else:
+        issues.append(
+            ValidationIssue(
+                path=("points",),
+                message="Points must be an array of objects.",
+            )
+        )
+
+    source_stats = payload.get("source_stats")
+    if not isinstance(source_stats, Mapping):
+        issues.append(
+            ValidationIssue(
+                path=("source_stats",),
+                message="source_stats must be an object (can be empty).",
+            )
+        )
+
+    truncated_value = payload.get("truncated")
+    if not isinstance(truncated_value, bool):
+        issues.append(
+            ValidationIssue(
+                path=("truncated",),
+                message="truncated must be a boolean flag.",
+            )
+        )
+
+    return tuple(issues)
+
+
+def _convert_to_extraction_result(payload: Mapping[str, Any]) -> ExtractionResult:
+    """Convert a validated payload to :class:`ExtractionResult`."""
+
+    points_payload = payload.get("points", [])
+    points = tuple(
+        ExtractedPoint(
+            id=str(point["id"]),
+            title=str(point["title"]),
+            summary=str(point["summary"]),
+            evidence_refs=tuple(str(item) for item in point.get("evidence_refs", [])),
+            confidence=float(point["confidence"]),
+            tags=tuple(str(item) for item in point.get("tags", [])),
+        )
+        for point in points_payload
+    )
+    source_stats = payload.get("source_stats")
+    return ExtractionResult(
+        points=points,
+        source_stats=dict(source_stats or {}),
+        truncated=bool(payload.get("truncated", False)),
+    )
+
+
+class ExtractionResponseParser:
+    """Parser that validates extraction responses and emits domain objects."""
+
+    def __init__(self, *, schema_name: str = "extraction.schema.json") -> None:
+        self._schema_name = schema_name
+
+    def parse(self, raw_text: str) -> StructuredParseResult[ExtractionResult]:
+        """Parse and validate an extraction response payload.
+
+        Args:
+            raw_text: Raw string returned by the language model invocation.
+
+        Returns:
+            :class:`StructuredParseResult` capturing the parsed payload, detected
+            validation issues, and a populated :class:`ExtractionResult` when
+            validation succeeds. When validation fails the returned result still
+            includes an :class:`ExtractionResult` carrying fallback metadata so
+            callers can persist the raw response alongside formatted error
+            messages.
+
+        Raises:
+            None. Validation errors are reported through the returned result.
+
+        Side Effects:
+            None.
+
+        Timeout:
+            Not applicable; parsing operates on in-memory strings synchronously.
+        """
+
+        parsed = parse_json_payload(raw_text)
+        if parsed.validation_errors:
+            fallback = _build_fallback_result(raw_text, parsed.validation_errors)
+            return StructuredParseResult(
+                raw_text=raw_text,
+                parsed_payload=parsed.parsed_payload,
+                validation_errors=parsed.validation_errors,
+                model=fallback,
+            )
+
+        assert parsed.parsed_payload is not None
+        validation_issues = _validate_extraction_payload(parsed.parsed_payload)
+        if validation_issues:
+            fallback = _build_fallback_result(raw_text, validation_issues)
+            return StructuredParseResult(
+                raw_text=raw_text,
+                parsed_payload=parsed.parsed_payload,
+                validation_errors=validation_issues,
+                model=fallback,
+            )
+
+        result = _convert_to_extraction_result(parsed.parsed_payload)
+        return StructuredParseResult(
+            raw_text=raw_text,
+            parsed_payload=parsed.parsed_payload,
+            validation_errors=(),
+            model=result,
+        )
+
+    def build_retry_message(self, issues: Sequence[ValidationIssue]) -> str:
+        """Render validation issues into guidance for a retry prompt.
+
+        Args:
+            issues: Collection of validation problems reported from the previous
+                parsing attempt.
+
+        Returns:
+            Formatted instructional string suitable for inclusion in a follow-up
+            user message to the model.
+
+        Raises:
+            None.
+
+        Side Effects:
+            None.
+
+        Timeout:
+            Not applicable; the function performs deterministic string formatting.
+        """
+
+        if not issues:
+            return (
+                "Previous response was valid; no retry guidance necessary."
+            )
+
+        formatted = "\n".join(f"- {issue.format()}" for issue in issues)
+        return textwrap.dedent(
+            f"""
+            The previous response failed validation against {self._schema_name}.
+            Correct the issues listed below and resend the payload as strict JSON:
+            {formatted}
+            Output only the corrected JSON with no extra commentary.
+            """
+        ).strip()
+
+
+__all__ = ["ExtractionResponseParser"]

--- a/src/application/preflight/orchestrator.py
+++ b/src/application/preflight/orchestrator.py
@@ -1,0 +1,152 @@
+"""Orchestrator for coordinating preflight extraction and query planning.
+
+Purpose:
+    Provide a thin coordination layer that sequences the extraction and query
+    building services ahead of the main critique pipeline. The orchestrator
+    ensures configuration toggles are honoured and that downstream callers
+    receive structured artefacts alongside recommended output locations.
+External Dependencies:
+    Relies exclusively on application-layer services and domain DTOs; no
+    framework or infrastructure modules are imported.
+Fallback Semantics:
+    Fallback handling is delegated to the injected services and their
+    respective gateways. This orchestrator simply propagates exceptions so the
+    caller can decide how to recover.
+Timeout Strategy:
+    The orchestrator does not enforce timeouts directly. Callers should wrap
+    invocations using :func:`src.infrastructure.timeouts.operation_timeout`
+    when coordinating with external providers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Mapping, Optional
+
+from ...domain.preflight import ExtractionResult, QueryPlan
+from ...pipeline_input import PipelineInput
+from .services import ExtractionService, QueryBuildingService
+
+
+@dataclass(slots=True, frozen=True)
+class PreflightOptions:
+    """Configuration toggles supplied to the preflight orchestrator.
+
+    Attributes:
+        enable_extraction: Flag indicating whether point extraction should run.
+        enable_query_building: Flag indicating whether query planning should
+            execute after extraction. Query building requires extraction to be
+            enabled to provide source points.
+        max_points: Optional limit to enforce when extracting points. ``None``
+            delegates limit selection to the extraction service defaults.
+        max_queries: Optional cap for the number of queries produced. ``None``
+            delegates to the query building service defaults.
+        metadata: Optional mapping propagated to both services to aid logging
+            or observability. A defensive copy is made before delegation.
+        extraction_artifact_name: Recommended relative path for persisting the
+            extraction result JSON. ``None`` disables artefact registration for
+            the extraction stage.
+        query_artifact_name: Recommended relative path for persisting the query
+            plan JSON. ``None`` disables artefact registration for the query
+            stage.
+    """
+
+    enable_extraction: bool = False
+    enable_query_building: bool = False
+    max_points: Optional[int] = None
+    max_queries: Optional[int] = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+    extraction_artifact_name: Optional[str] = "artifacts/points.json"
+    query_artifact_name: Optional[str] = "artifacts/queries.json"
+
+
+@dataclass
+class PreflightRunResult:
+    """Container capturing the outputs of the preflight orchestrator.
+
+    Attributes:
+        extraction: Structured extraction result when the extraction stage ran.
+        query_plan: Structured query plan when query building was executed.
+        artifact_paths: Mapping of logical artefact identifiers to recommended
+            relative output paths within a run's artefacts directory. Callers
+            may mutate the mapping after persisting files to record absolute
+            paths.
+    """
+
+    extraction: Optional[ExtractionResult] = None
+    query_plan: Optional[QueryPlan] = None
+    artifact_paths: Dict[str, str] = field(default_factory=dict)
+
+    def has_outputs(self) -> bool:
+        """Return ``True`` when at least one preflight stage produced output."""
+
+        return self.extraction is not None or self.query_plan is not None
+
+
+@dataclass(slots=True)
+class PreflightOrchestrator:
+    """Sequence extraction and query planning according to supplied options."""
+
+    extraction_service: ExtractionService
+    query_service: QueryBuildingService
+
+    def run(self, pipeline_input: PipelineInput, options: PreflightOptions) -> PreflightRunResult:
+        """Execute preflight stages based on the provided options.
+
+        Args:
+            pipeline_input: Normalised corpus supplied to both services.
+            options: Configuration toggles describing which stages to execute
+                and how to label resulting artefacts.
+
+        Returns:
+            Populated :class:`PreflightRunResult` describing generated artefacts
+            and recommended output paths.
+
+        Raises:
+            ValueError: If query building is requested without enabling
+                extraction first.
+            RuntimeError: Propagated from the underlying services when
+                extraction or query planning fail.
+
+        Side Effects:
+            Delegates to services that may perform network I/O.
+
+        Timeout:
+            Not enforced. Callers should provide their own timeout management.
+        """
+
+        if options.enable_query_building and not options.enable_extraction:
+            raise ValueError("Query building requires extraction to be enabled.")
+
+        artifact_paths: Dict[str, str] = {}
+        extraction_result: Optional[ExtractionResult] = None
+        query_plan: Optional[QueryPlan] = None
+        metadata_copy = dict(options.metadata)
+
+        if options.enable_extraction:
+            extraction_result = self.extraction_service.run(
+                pipeline_input,
+                max_points=options.max_points,
+                metadata=metadata_copy or None,
+            )
+            if options.extraction_artifact_name:
+                artifact_paths["extraction"] = options.extraction_artifact_name
+
+        if options.enable_query_building:
+            query_plan = self.query_service.run(
+                extraction_result,
+                pipeline_input,
+                max_queries=options.max_queries,
+                metadata=metadata_copy or None,
+            )
+            if options.query_artifact_name:
+                artifact_paths["query_plan"] = options.query_artifact_name
+
+        return PreflightRunResult(
+            extraction=extraction_result,
+            query_plan=query_plan,
+            artifact_paths=artifact_paths,
+        )
+
+
+__all__ = ["PreflightOptions", "PreflightOrchestrator", "PreflightRunResult"]

--- a/src/application/preflight/ports.py
+++ b/src/application/preflight/ports.py
@@ -1,0 +1,102 @@
+"""Interface contracts for preflight extraction and query planning.
+
+Purpose:
+    Define framework-agnostic ports that decouple presentation and
+    infrastructure layers from the orchestration logic required for point
+    extraction and query building. These protocols allow adapters to depend on
+    abstractions owned by the application layer, satisfying the project's clean
+    architecture rules.
+External Dependencies:
+    Relies exclusively on Python's standard library ``typing`` module and shared
+    domain DTOs.
+Fallback Semantics:
+    No fallback logic is expressed at the contract level. Implementations may
+    supply retries or degrade gracefully while reporting structured errors.
+Timeout Strategy:
+    Timeouts are not enforced within the interfaces. Callers are expected to wrap
+    blocking calls using higher-level ``operation_timeout`` utilities when
+    coordinating with external providers.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping, Optional, Protocol
+
+from ...pipeline_input import PipelineInput
+from ...domain.preflight import ExtractionResult, QueryPlan
+
+
+class PointExtractorGateway(Protocol):
+    """Abstraction responsible for converting raw input into structured points."""
+
+    def extract_points(
+        self,
+        pipeline_input: PipelineInput,
+        *,
+        max_points: Optional[int] = None,
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> ExtractionResult:
+        """Extract salient points from the supplied pipeline input.
+
+        Args:
+            pipeline_input: Normalised representation of the corpus to analyse.
+            max_points: Optional cap applied by orchestration logic. Implementers
+                must respect the limit when provided.
+            metadata: Optional contextual hints such as run identifiers or
+                selection strategies. Implementations should treat the mapping as
+                read-only.
+
+        Returns:
+            Structured extraction result containing zero or more points.
+
+        Raises:
+            RuntimeError: Implementations may raise when provider operations fail
+                irrecoverably. The type should be implementation-specific to aid
+                diagnostics.
+
+        Side Effects:
+            May invoke external providers or perform I/O depending on the
+            concrete adapter.
+
+        Timeout:
+            Determined by implementations. Callers should apply ``operation_timeout``
+            at higher layers when needed.
+        """
+
+
+class QueryBuilderGateway(Protocol):
+    """Abstraction responsible for deriving follow-up queries from points."""
+
+    def build_queries(
+        self,
+        extraction: ExtractionResult,
+        pipeline_input: Optional[PipelineInput] = None,
+        *,
+        max_queries: Optional[int] = None,
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> QueryPlan:
+        """Construct a query plan based on extracted points and optional context.
+
+        Args:
+            extraction: Result produced by :class:`PointExtractorGateway`.
+            pipeline_input: Optional original corpus for reference when crafting
+                queries.
+            max_queries: Optional cap for the number of queries generated.
+            metadata: Optional contextual hints or run metadata.
+
+        Returns:
+            Query plan enumerating queries, rationale, and related context.
+
+        Raises:
+            RuntimeError: When the gateway encounters unrecoverable provider
+                issues.
+
+        Side Effects:
+            May call external services or log structured observability data.
+
+        Timeout:
+            Managed by the implementation or by caller-supplied wrappers.
+        """
+
+
+__all__ = ["PointExtractorGateway", "QueryBuilderGateway"]

--- a/src/application/preflight/prompts.py
+++ b/src/application/preflight/prompts.py
@@ -1,0 +1,329 @@
+"""Prompt builders for preflight extraction and query planning requests.
+
+Purpose:
+    Provide reusable functions that assemble deterministic system and user
+    prompts for the preflight workflows. The functions embed JSON Schemas and
+    guardrails so large language model providers can emit structured outputs that
+    map cleanly to the domain DTOs defined for extraction and query planning.
+External Dependencies:
+    Python standard library modules only (``json`` and ``textwrap``).
+Fallback Semantics:
+    Prompt construction is pure and has no fallbacks. Higher layers are expected
+    to perform retries when model outputs fail validation.
+Timeout Strategy:
+    Not applicable. Prompt generation performs no blocking I/O and therefore
+    does not require timeout handling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Mapping, Optional
+import textwrap
+
+from ...domain.preflight import ExtractionResult
+from ...pipeline_input import PipelineInput
+
+
+@dataclass(frozen=True)
+class PromptBundle:
+    """Container holding the system and user prompt for a model request."""
+
+    system: str
+    user: str
+
+
+def _serialise_schema(schema: Mapping[str, object]) -> str:
+    """Return a deterministic JSON representation of a JSON Schema.
+
+    Args:
+        schema: Parsed JSON Schema mapping.
+
+    Returns:
+        Readable JSON string formatted with two-space indentation for embedding
+        into prompts.
+
+    Raises:
+        TypeError: If ``schema`` contains objects that cannot be serialised to
+            JSON by :func:`json.dumps`.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; the operation is CPU-bound and runs synchronously.
+    """
+
+    return json.dumps(schema, indent=2, sort_keys=True)
+
+
+def _build_extraction_system_prompt(max_points: Optional[int]) -> str:
+    """Create the system prompt for the extraction workflow.
+
+    Args:
+        max_points: Optional hard limit on the number of points to return.
+
+    Returns:
+        String instructing the model on its role, guardrails, and format
+        requirements.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; the function performs only string formatting.
+    """
+
+    limit_clause = (
+        f" Return no more than {max_points} points even if more appear relevant."
+        if max_points is not None
+        else " Respect any explicit point limits communicated in the user instructions."
+    )
+    return textwrap.dedent(
+        f"""
+        You are an expert research analyst tasked with extracting the most
+        consequential findings from technical documents. Prioritise factual
+        accuracy, cite supporting evidence, and avoid speculation.{limit_clause}
+        Respond strictly in JSON that conforms to the provided schema. Do not
+        include markdown fences, commentary, or additional explanations.
+        """
+    ).strip()
+
+
+def _format_pipeline_metadata(pipeline_input: PipelineInput) -> str:
+    """Render a short metadata block describing the pipeline input source.
+
+    Args:
+        pipeline_input: Canonical pipeline input for the run.
+
+    Returns:
+        Human-readable description including source hints and metadata flags.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; the routine is CPU-bound and executes synchronously.
+    """
+
+    metadata = dict(pipeline_input.metadata or {})
+    source = pipeline_input.source or "unspecified-source"
+    truncated = metadata.get("truncated") or metadata.get("is_truncated")
+    char_count = len(pipeline_input.content)
+    lines = [f"Source: {source}"]
+    lines.append(f"Characters: {char_count}")
+    if truncated:
+        lines.append("Repository truncation: true")
+    if "files" in metadata:
+        try:
+            file_count = len(metadata["files"])  # type: ignore[index]
+            lines.append(f"Files aggregated: {file_count}")
+        except TypeError:
+            lines.append("Files aggregated: unknown")
+    return "\n".join(lines)
+
+
+def build_extraction_prompt(
+    pipeline_input: PipelineInput,
+    schema: Mapping[str, object],
+    *,
+    max_points: Optional[int] = None,
+) -> PromptBundle:
+    """Construct the prompt bundle for the extraction gateway call.
+
+    Args:
+        pipeline_input: Normalised pipeline input containing the content corpus.
+        schema: Parsed JSON Schema describing the expected response structure.
+        max_points: Optional cap on the number of points to request from the
+            model.
+
+    Returns:
+        :class:`PromptBundle` containing system and user prompts ready to send to
+        a provider client.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; execution performs only string composition.
+    """
+
+    schema_json = _serialise_schema(schema)
+    system_prompt = _build_extraction_system_prompt(max_points)
+    limit_instructions = (
+        f"Return no more than {max_points} points. " if max_points is not None else ""
+    )
+    user_prompt = textwrap.dedent(
+        f"""
+        Extract the most salient points from the provided content. {limit_instructions}
+        Each point must include a stable identifier, a concise title, a detailed
+        summary, supporting evidence references, a confidence score between 0 and
+        1, and optional thematic tags. If you must omit potentially relevant
+        points due to limits or token constraints, set "truncated" to true and
+        include the strongest points first.
+
+        === Pipeline Input Metadata ===
+        {_format_pipeline_metadata(pipeline_input)}
+
+        === Content ===
+        {pipeline_input.content}
+
+        === Required JSON Schema ===
+        {schema_json}
+        """
+    ).strip()
+    return PromptBundle(system=system_prompt, user=user_prompt)
+
+
+def _build_query_system_prompt(max_queries: Optional[int]) -> str:
+    """Create the system prompt for the query planning workflow.
+
+    Args:
+        max_queries: Optional cap on the number of queries to produce.
+
+    Returns:
+        System message instructing the model on planning responsibilities.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; the function performs deterministic string formatting.
+    """
+
+    limit_clause = (
+        f" Limit the plan to {max_queries} queries prioritised by impact."
+        if max_queries is not None
+        else " Ensure the plan is concise and prioritised."
+    )
+    return textwrap.dedent(
+        f"""
+        You are a research planning assistant. Review the extracted points and
+        design precise follow-up queries that close knowledge gaps or validate
+        critical claims.{limit_clause} Provide structured output only and respect
+        declared dependencies between queries.
+        """
+    ).strip()
+
+
+def _format_points_for_prompt(extraction: ExtractionResult) -> str:
+    """Render extracted points into a compact text block for prompts.
+
+    Args:
+        extraction: Structured extraction result from the upstream workflow.
+
+    Returns:
+        Multi-line string describing each point with identifiers and summaries.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; the function iterates over in-memory data only.
+    """
+
+    lines = []
+    for index, point in enumerate(extraction.points, start=1):
+        evidence = ", ".join(point.evidence_refs) or "(no evidence references)"
+        tags = ", ".join(point.tags) or "(no tags)"
+        lines.append(
+            textwrap.dedent(
+                f"""
+                [{index}] id={point.id}
+                title={point.title}
+                summary={point.summary}
+                evidence={evidence}
+                confidence={point.confidence}
+                tags={tags}
+                """
+            ).strip()
+        )
+    if not lines:
+        return "(no points extracted)"
+    return "\n\n".join(lines)
+
+
+def build_query_plan_prompt(
+    extraction: ExtractionResult,
+    schema: Mapping[str, object],
+    *,
+    pipeline_input: Optional[PipelineInput] = None,
+    max_queries: Optional[int] = None,
+) -> PromptBundle:
+    """Construct the prompt bundle for the query planning gateway call.
+
+    Args:
+        extraction: Structured extraction result containing the points to use.
+        schema: Parsed JSON Schema describing the query plan response.
+        pipeline_input: Optional original pipeline input to provide additional
+            context for crafting queries.
+        max_queries: Optional cap on the number of queries to request.
+
+    Returns:
+        :class:`PromptBundle` containing the system and user prompts.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; execution composes strings synchronously.
+    """
+
+    schema_json = _serialise_schema(schema)
+    system_prompt = _build_query_system_prompt(max_queries)
+    limit_instructions = (
+        f"Return no more than {max_queries} queries. " if max_queries is not None else ""
+    )
+    contextual_blurb = (
+        textwrap.dedent(
+            f"""
+            === Pipeline Input Metadata ===
+            {_format_pipeline_metadata(pipeline_input)}
+
+            === Content ===
+            {pipeline_input.content}
+            """
+        ).strip()
+        if pipeline_input is not None
+        else ""
+    )
+    user_prompt = textwrap.dedent(
+        f"""
+        Review the extracted points and build a follow-up query plan. {limit_instructions}
+        Every query must describe its purpose, priority, and any dependencies on
+        earlier queries. Prefer concrete, actionable questions tied to specific
+        evidence. Recommend specialised tooling when it meaningfully improves the
+        investigation.
+
+        === Extracted Points ===
+        {_format_points_for_prompt(extraction)}
+
+        {contextual_blurb}
+
+        === Required JSON Schema ===
+        {schema_json}
+        """
+    ).strip()
+    return PromptBundle(system=system_prompt, user=user_prompt)
+
+
+__all__ = ["PromptBundle", "build_extraction_prompt", "build_query_plan_prompt"]

--- a/src/application/preflight/query_parser.py
+++ b/src/application/preflight/query_parser.py
@@ -1,0 +1,357 @@
+"""Query plan response parsing utilities for preflight workflows.
+
+Purpose:
+    Validate structured query plans emitted by language models and convert them
+    into domain objects suitable for downstream orchestration. The module keeps
+    the validation logic for :class:`~src.domain.preflight.QueryPlan` centralised
+    so higher layers can remain thin.
+External Dependencies:
+    Python standard library modules ``textwrap`` and ``typing`` alongside local
+    schema validation helpers.
+Fallback Semantics:
+    The parser surfaces structured validation errors and produces fallback
+    artefacts containing the raw provider response together with formatted error
+    messages. Callers can persist the fallback result while signalling that the
+    payload failed schema validation.
+Timeout Strategy:
+    Not applicable; parsing and validation operate entirely in memory.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+from ...domain.preflight import BuiltQuery, QueryPlan
+from .schema_validation import (
+    StructuredParseResult,
+    ValidationIssue,
+    parse_json_payload,
+    reject_additional_keys,
+    require_keys,
+    validate_string_array,
+)
+
+
+def _validate_built_query(
+    item: Any,
+    *,
+    index: int,
+    issues: list[ValidationIssue],
+) -> Optional[BuiltQuery]:
+    """Validate and convert a potential built query payload."""
+
+    path = ("queries", str(index))
+    if not isinstance(item, Mapping):
+        issues.append(
+            ValidationIssue(
+                path=path,
+                message="Each query must be an object with the documented properties.",
+            )
+        )
+        return None
+
+    required = ["id", "text", "purpose", "priority"]
+    allowed = [
+        "id",
+        "text",
+        "purpose",
+        "priority",
+        "depends_on_ids",
+        "target_audience",
+        "suggested_tooling",
+    ]
+    require_keys(item, required, path=path, issues=issues)
+    reject_additional_keys(item, allowed, path=path, issues=issues)
+
+    id_value = item.get("id")
+    text_value = item.get("text")
+    purpose_value = item.get("purpose")
+    priority_value = item.get("priority")
+
+    for key, value in ("id", id_value), ("text", text_value), ("purpose", purpose_value):
+        if not isinstance(value, str) or not value.strip():
+            issues.append(
+                ValidationIssue(
+                    path=path + (key,),
+                    message="Value must be a non-empty string.",
+                )
+            )
+
+    if not isinstance(priority_value, int):
+        issues.append(
+            ValidationIssue(
+                path=path + ("priority",),
+                message="priority must be an integer.",
+            )
+        )
+
+    depends_on: Tuple[str, ...] = ()
+    if "depends_on_ids" in item:
+        depends_on = validate_string_array(
+            item["depends_on_ids"],
+            path=path + ("depends_on_ids",),
+            issues=issues,
+        )
+
+    suggested_tooling: Tuple[str, ...] = ()
+    if "suggested_tooling" in item:
+        suggested_tooling = validate_string_array(
+            item["suggested_tooling"],
+            path=path + ("suggested_tooling",),
+            issues=issues,
+        )
+
+    target_audience = item.get("target_audience")
+    if target_audience is not None and not isinstance(target_audience, str):
+        issues.append(
+            ValidationIssue(
+                path=path + ("target_audience",),
+                message="target_audience must be null or a string.",
+            )
+        )
+
+    if any(issue.path[:2] == path[:2] for issue in issues):
+        return None
+
+    return BuiltQuery(
+        id=str(id_value),
+        text=str(text_value),
+        purpose=str(purpose_value),
+        priority=int(priority_value) if isinstance(priority_value, int) else 0,
+        depends_on_ids=depends_on,
+        target_audience=target_audience if isinstance(target_audience, str) else None,
+        suggested_tooling=suggested_tooling,
+    )
+
+
+def _format_validation_messages(issues: Sequence[ValidationIssue]) -> Tuple[str, ...]:
+    """Return formatted string representations of validation issues.
+
+    Args:
+        issues: Validation problems encountered while parsing model output.
+
+    Returns:
+        Tuple containing human-readable error descriptions. Returns an empty
+        tuple when no issues were supplied.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None. The function performs deterministic string formatting only.
+
+    Timeout:
+        Not applicable; execution is CPU-bound and synchronous.
+    """
+
+    return tuple(issue.format() for issue in issues)
+
+
+def _build_fallback_plan(
+    raw_text: str,
+    issues: Sequence[ValidationIssue],
+) -> QueryPlan:
+    """Construct a fallback query plan when validation fails.
+
+    Args:
+        raw_text: Raw JSON or JSON-like string returned by the language model.
+        issues: Validation errors detected while parsing ``raw_text``.
+
+    Returns:
+        :class:`QueryPlan` instance containing no structured queries but
+        preserving the raw response and formatted validation error messages for
+        downstream observability.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None. A new domain object is returned without mutating external state.
+
+    Timeout:
+        Not applicable; the helper performs simple data transformations.
+    """
+
+    return QueryPlan(
+        queries=(),
+        rationale="",
+        assumptions=(),
+        risks=(),
+        raw_response=raw_text,
+        validation_errors=_format_validation_messages(issues),
+    )
+
+
+def _validate_query_plan_payload(payload: Any) -> Tuple[ValidationIssue, ...]:
+    """Return validation issues for a potential query plan payload."""
+
+    issues: list[ValidationIssue] = []
+    if not isinstance(payload, Mapping):
+        issues.append(
+            ValidationIssue(path=(), message="Root payload must be a JSON object."),
+        )
+        return tuple(issues)
+
+    required = ["queries", "rationale"]
+    allowed = ["queries", "rationale", "assumptions", "risks"]
+    require_keys(payload, required, path=(), issues=issues)
+    reject_additional_keys(payload, allowed, path=(), issues=issues)
+
+    queries_value = payload.get("queries")
+    if isinstance(queries_value, Sequence) and not isinstance(queries_value, (str, bytes)):
+        for index, item in enumerate(queries_value):
+            _validate_built_query(item, index=index, issues=issues)
+    else:
+        issues.append(
+            ValidationIssue(
+                path=("queries",),
+                message="queries must be an array of objects.",
+            )
+        )
+
+    rationale_value = payload.get("rationale")
+    if not isinstance(rationale_value, str):
+        issues.append(
+            ValidationIssue(
+                path=("rationale",),
+                message="rationale must be a string (can be empty).",
+            )
+        )
+
+    for array_key in ("assumptions", "risks"):
+        if array_key in payload:
+            validate_string_array(
+                payload[array_key],
+                path=(array_key,),
+                issues=issues,
+            )
+
+    return tuple(issues)
+
+
+def _convert_to_query_plan(payload: Mapping[str, Any]) -> QueryPlan:
+    """Convert a validated payload to :class:`QueryPlan`."""
+
+    queries_payload = payload.get("queries", [])
+    queries = tuple(
+        BuiltQuery(
+            id=str(item["id"]),
+            text=str(item["text"]),
+            purpose=str(item["purpose"]),
+            priority=int(item["priority"]),
+            depends_on_ids=tuple(str(dep) for dep in item.get("depends_on_ids", [])),
+            target_audience=(
+                str(item["target_audience"])
+                if isinstance(item.get("target_audience"), str)
+                else None
+            ),
+            suggested_tooling=tuple(str(tool) for tool in item.get("suggested_tooling", [])),
+        )
+        for item in queries_payload
+    )
+    return QueryPlan(
+        queries=queries,
+        rationale=str(payload.get("rationale", "")),
+        assumptions=tuple(str(item) for item in payload.get("assumptions", [])),
+        risks=tuple(str(item) for item in payload.get("risks", [])),
+    )
+
+
+class QueryPlanResponseParser:
+    """Parser that validates query plan responses and emits domain objects."""
+
+    def __init__(self, *, schema_name: str = "query_plan.schema.json") -> None:
+        self._schema_name = schema_name
+
+    def parse(self, raw_text: str) -> StructuredParseResult[QueryPlan]:
+        """Parse and validate a query plan response payload.
+
+        Args:
+            raw_text: Raw JSON-like string emitted by the query planning model.
+
+        Returns:
+            :class:`StructuredParseResult` with the parsed payload, any
+            validation issues, and a :class:`QueryPlan` instance when validation
+            is successful. When validation fails the returned result embeds a
+            fallback :class:`QueryPlan` carrying the raw response and formatted
+            error messages so callers can persist observability data while
+            reacting to the failure.
+
+        Raises:
+            None. Validation feedback is surfaced within the returned result.
+
+        Side Effects:
+            None.
+
+        Timeout:
+            Not applicable; execution is CPU-bound and synchronous.
+        """
+
+        parsed = parse_json_payload(raw_text)
+        if parsed.validation_errors:
+            fallback = _build_fallback_plan(raw_text, parsed.validation_errors)
+            return StructuredParseResult(
+                raw_text=raw_text,
+                parsed_payload=parsed.parsed_payload,
+                validation_errors=parsed.validation_errors,
+                model=fallback,
+            )
+
+        assert parsed.parsed_payload is not None
+        validation_issues = _validate_query_plan_payload(parsed.parsed_payload)
+        if validation_issues:
+            fallback = _build_fallback_plan(raw_text, validation_issues)
+            return StructuredParseResult(
+                raw_text=raw_text,
+                parsed_payload=parsed.parsed_payload,
+                validation_errors=validation_issues,
+                model=fallback,
+            )
+
+        plan = _convert_to_query_plan(parsed.parsed_payload)
+        return StructuredParseResult(
+            raw_text=raw_text,
+            parsed_payload=parsed.parsed_payload,
+            validation_errors=(),
+            model=plan,
+        )
+
+    def build_retry_message(self, issues: Sequence[ValidationIssue]) -> str:
+        """Render validation issues into guidance for a retry prompt.
+
+        Args:
+            issues: Collection of validation errors that must be addressed before
+                accepting the response.
+
+        Returns:
+            String containing retry guidance for the model, including the list of
+            issues that should be resolved.
+
+        Raises:
+            None.
+
+        Side Effects:
+            None.
+
+        Timeout:
+            Not applicable; the method formats strings synchronously.
+        """
+
+        if not issues:
+            return (
+                "Previous response was valid; no retry guidance necessary."
+            )
+
+        formatted = "\n".join(f"- {issue.format()}" for issue in issues)
+        return textwrap.dedent(
+            f"""
+            The previous response failed validation against {self._schema_name}.
+            Address the problems listed below and resend a corrected JSON payload:
+            {formatted}
+            Output only the corrected JSON with no additional commentary.
+            """
+        ).strip()
+
+
+__all__ = ["QueryPlanResponseParser"]

--- a/src/application/preflight/schema_validation.py
+++ b/src/application/preflight/schema_validation.py
@@ -1,0 +1,270 @@
+"""Shared schema validation utilities for preflight structured outputs.
+
+Purpose:
+    Provide reusable helpers for parsing JSON payloads emitted by large language
+    models and validating them according to the expected structural constraints.
+    These utilities are intentionally domain-agnostic so both extraction and
+    query planning parsers can reuse them without duplicating logic.
+External Dependencies:
+    Python standard library only (``dataclasses``, ``json``, and ``typing``).
+Fallback Semantics:
+    Validation helpers report structured issues rather than raising exceptions.
+    Callers are responsible for implementing retry or fallback behaviour.
+Timeout Strategy:
+    Not applicable; the module performs only in-memory operations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any, Generic, Iterable, Mapping, Optional, Sequence, Tuple, TypeVar
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """Represents a single schema validation issue detected in a payload."""
+
+    path: Tuple[str, ...]
+    message: str
+
+    def format(self) -> str:
+        """Render the issue into a human-readable string.
+
+        Returns:
+            String describing the validation error with its JSON pointer-like
+            location.
+
+        Raises:
+            None.
+
+        Side Effects:
+            None.
+
+        Timeout:
+            Not applicable; the method performs simple string concatenation.
+        """
+
+        location = "/".join(self.path) if self.path else "<root>"
+        return f"{location}: {self.message}"
+
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class StructuredParseResult(Generic[T]):
+    """Container summarising the outcome of parsing and validation."""
+
+    raw_text: str
+    parsed_payload: Optional[Any]
+    validation_errors: Tuple[ValidationIssue, ...]
+    model: Optional[T]
+
+    @property
+    def is_valid(self) -> bool:
+        """Return ``True`` when parsing succeeded and the model instance is available.
+
+        Returns:
+            ``True`` when ``model`` is populated and no validation errors were
+            recorded, otherwise ``False``.
+
+        Raises:
+            None.
+
+        Side Effects:
+            None.
+
+        Timeout:
+            Not applicable; property evaluation is instantaneous.
+        """
+
+        return self.model is not None and not self.validation_errors
+
+
+def parse_json_payload(raw_text: str) -> StructuredParseResult[Any]:
+    """Attempt to parse ``raw_text`` as JSON without schema validation.
+
+    Args:
+        raw_text: Raw string returned by the language model invocation.
+
+    Returns:
+        :class:`StructuredParseResult` with the parsed payload populated on
+        success. When parsing fails the result contains a corresponding
+        :class:`ValidationIssue` and ``parsed_payload`` is ``None``.
+
+    Raises:
+        None. Parsing errors are captured in the returned result.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; JSON parsing operates synchronously in memory.
+    """
+
+    try:
+        payload = json.loads(raw_text)
+    except json.JSONDecodeError as exc:  # pragma: no cover - exercised in tests
+        issue = ValidationIssue(
+            path=(),
+            message=(
+                f"Invalid JSON at line {exc.lineno} column {exc.colno}: {exc.msg}. "
+                "Ensure the response is raw JSON without commentary."
+            ),
+        )
+        return StructuredParseResult(
+            raw_text=raw_text,
+            parsed_payload=None,
+            validation_errors=(issue,),
+            model=None,
+        )
+
+    return StructuredParseResult(
+        raw_text=raw_text,
+        parsed_payload=payload,
+        validation_errors=(),
+        model=None,
+    )
+
+
+def require_keys(
+    data: Mapping[str, Any],
+    required: Sequence[str],
+    *,
+    path: Tuple[str, ...],
+    issues: list[ValidationIssue],
+) -> None:
+    """Ensure that ``required`` keys exist within ``data``.
+
+    Args:
+        data: Mapping being inspected.
+        required: Sequence of key names that must be present.
+        path: Location of ``data`` within the overall payload, used for error
+            reporting.
+        issues: Mutable list that collects encountered validation problems.
+
+    Returns:
+        ``None``. Issues are appended to ``issues`` when violations occur.
+
+    Raises:
+        None.
+
+    Side Effects:
+        Appends :class:`ValidationIssue` instances to ``issues`` when keys are
+        missing.
+
+    Timeout:
+        Not applicable; the check iterates over a finite sequence synchronously.
+    """
+
+    for key in required:
+        if key not in data:
+            issues.append(
+                ValidationIssue(path=path + (key,), message="Missing required property."),
+            )
+
+
+def reject_additional_keys(
+    data: Mapping[str, Any],
+    allowed: Iterable[str],
+    *,
+    path: Tuple[str, ...],
+    issues: list[ValidationIssue],
+) -> None:
+    """Ensure ``data`` does not expose properties outside ``allowed``.
+
+    Args:
+        data: Mapping being validated.
+        allowed: Iterable of property names that are permitted.
+        path: Location of ``data`` within the larger payload.
+        issues: Mutable list receiving validation problems.
+
+    Returns:
+        ``None``. Any unexpected properties are appended to ``issues``.
+
+    Raises:
+        None.
+
+    Side Effects:
+        Appends :class:`ValidationIssue` entries to ``issues`` for disallowed
+        properties.
+
+    Timeout:
+        Not applicable; the function iterates deterministically over ``data``.
+    """
+
+    allowed_set = set(allowed)
+    for key in data:
+        if key not in allowed_set:
+            issues.append(
+                ValidationIssue(
+                    path=path + (key,),
+                    message="Property is not allowed by the schema.",
+                )
+            )
+
+
+def validate_string_array(
+    value: Any,
+    *,
+    path: Tuple[str, ...],
+    issues: list[ValidationIssue],
+    allow_empty: bool = True,
+) -> Tuple[str, ...]:
+    """Validate that ``value`` represents a sequence of non-empty strings.
+
+    Args:
+        value: Candidate array value.
+        path: Location of the array in the payload for diagnostics.
+        issues: Mutable list capturing validation problems.
+        allow_empty: When ``False`` the array must contain at least one string.
+
+    Returns:
+        Tuple of strings extracted from ``value`` when validation succeeds. When
+        validation fails an empty tuple is returned and issues are appended to
+        ``issues``.
+
+    Raises:
+        None.
+
+    Side Effects:
+        Appends :class:`ValidationIssue` entries to ``issues`` when validation
+        fails.
+
+    Timeout:
+        Not applicable; iteration is bounded by the size of ``value``.
+    """
+
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        issues.append(
+            ValidationIssue(path=path, message="Expected an array of strings."),
+        )
+        return ()
+
+    items: list[str] = []
+    for index, element in enumerate(value):
+        if not isinstance(element, str) or not element.strip():
+            issues.append(
+                ValidationIssue(
+                    path=path + (str(index),),
+                    message="Each entry must be a non-empty string.",
+                )
+            )
+        else:
+            items.append(element)
+
+    if not allow_empty and not items:
+        issues.append(ValidationIssue(path=path, message="Array must not be empty."))
+
+    return tuple(items)
+
+
+__all__ = [
+    "ValidationIssue",
+    "StructuredParseResult",
+    "parse_json_payload",
+    "reject_additional_keys",
+    "require_keys",
+    "validate_string_array",
+]

--- a/src/application/preflight/schemas.py
+++ b/src/application/preflight/schemas.py
@@ -1,0 +1,86 @@
+"""Utility helpers for loading preflight JSON Schemas from disk.
+
+Purpose:
+    Centralise loading of the JSON Schema documents used for preflight
+    extraction and query planning so application services can embed them in
+    prompts and validators without duplicating path logic.
+External Dependencies:
+    Python standard library only (``functools`` and ``json``).
+Fallback Semantics:
+    Schema loading is deterministic and raises ``FileNotFoundError`` if assets are
+    missing. Callers may catch and handle these exceptions depending on their
+    resiliency requirements.
+Timeout Strategy:
+    Not applicable because the module performs synchronous file reads on local
+    assets.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+import json
+from pathlib import Path
+from typing import Mapping
+from copy import deepcopy
+
+
+_SCHEMA_DIRECTORY = Path(__file__).resolve().parent.parent.parent / "contexts" / "schemas"
+
+
+def _load_schema(filename: str) -> Mapping[str, object]:
+    """Load a JSON Schema document from the schema directory."""
+
+    path = _SCHEMA_DIRECTORY / filename
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+@lru_cache(maxsize=2)
+def _load_cached_schema(filename: str) -> Mapping[str, object]:
+    """Load and cache the schema contents for reuse across the process."""
+
+    return _load_schema(filename)
+
+
+def load_extraction_schema() -> Mapping[str, object]:
+    """Return the schema for the :class:`~src.domain.preflight.ExtractionResult`.
+
+    Returns:
+        Copy of the JSON Schema mapping describing the extraction result
+        structure.
+
+    Raises:
+        FileNotFoundError: If the schema asset cannot be located.
+        json.JSONDecodeError: If the schema file cannot be parsed as JSON.
+
+    Side Effects:
+        Reads the schema file from disk.
+
+    Timeout:
+        Not applicable; file access is local and synchronous.
+    """
+
+    return deepcopy(_load_cached_schema("extraction.schema.json"))
+
+
+def load_query_plan_schema() -> Mapping[str, object]:
+    """Return the schema for the :class:`~src.domain.preflight.QueryPlan`.
+
+    Returns:
+        Copy of the JSON Schema mapping describing the query plan structure.
+
+    Raises:
+        FileNotFoundError: If the schema asset cannot be located.
+        json.JSONDecodeError: If the schema file is not valid JSON.
+
+    Side Effects:
+        Reads the schema file from disk.
+
+    Timeout:
+        Not applicable; reading the local file is synchronous.
+    """
+
+    return deepcopy(_load_cached_schema("query_plan.schema.json"))
+
+
+__all__ = ["load_extraction_schema", "load_query_plan_schema"]

--- a/src/application/preflight/services.py
+++ b/src/application/preflight/services.py
@@ -1,0 +1,171 @@
+"""Application services orchestrating preflight extraction workflows.
+
+Purpose:
+    Provide thin, testable coordinators that delegate heavy lifting to gateway
+    interfaces. The services expose a straightforward API for presentation and
+    orchestration layers to trigger extraction and query planning while keeping
+    business logic free from framework concerns.
+External Dependencies:
+    Uses only Python standard library modules ``dataclasses`` and ``typing``
+    alongside internal domain DTOs and pipeline primitives.
+Fallback Semantics:
+    Fallback and retry strategies are owned by the injected gateway
+    implementations. The services propagate errors to the caller so they can
+    decide how to respond (retry, fallback, or abort).
+Timeout Strategy:
+    No explicit timeouts are enforced in this module. Callers should manage
+    timing concerns using higher-level ``operation_timeout`` utilities when
+    interacting with external systems.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+from ...domain.preflight import ExtractionResult, QueryPlan
+from ...pipeline_input import PipelineInput
+from .ports import PointExtractorGateway, QueryBuilderGateway
+
+
+def _validate_limit(limit: Optional[int], *, parameter_name: str) -> Optional[int]:
+    """Validate numeric limits supplied to service operations.
+
+    Args:
+        limit: Optional numeric limit to validate.
+        parameter_name: Human-readable name used in error messages.
+
+    Returns:
+        The original ``limit`` when valid.
+
+    Raises:
+        ValueError: If ``limit`` is provided and evaluates to zero or a negative
+            number.
+    """
+
+    if limit is None:
+        return None
+    if limit <= 0:
+        raise ValueError(f"{parameter_name} must be a positive integer when provided")
+    return limit
+
+
+@dataclass(slots=True)
+class ExtractionService:
+    """Coordinates calls to the :class:`PointExtractorGateway`.
+
+    The service centralises handling of default configuration such as maximum
+    point counts while leaving extraction details to the gateway. The dataclass
+    is declared with ``slots`` to keep instances lightweight and to discourage
+    runtime mutation of attributes outside the declared fields.
+    """
+
+    gateway: PointExtractorGateway
+    default_max_points: Optional[int] = None
+
+    def run(
+        self,
+        pipeline_input: PipelineInput,
+        *,
+        max_points: Optional[int] = None,
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> ExtractionResult:
+        """Execute the point extraction workflow.
+
+        Args:
+            pipeline_input: Normalised representation of the corpus to analyse.
+            max_points: Optional override for the number of points to request.
+            metadata: Optional contextual data for downstream logging or
+                providers. A defensive copy is created to prevent accidental
+                mutation by callers during gateway execution.
+
+        Returns:
+            Structured extraction result produced by the gateway.
+
+        Raises:
+            ValueError: If ``max_points`` is provided but not positive.
+            RuntimeError: Propagated from the gateway implementation when
+                extraction fails.
+
+        Side Effects:
+            The gateway may perform I/O or invoke external services. The service
+            itself does not have additional side effects.
+
+        Timeout:
+            Not enforced. Callers are expected to handle timeouts externally if
+            required.
+        """
+
+        effective_limit = _validate_limit(
+            max_points if max_points is not None else self.default_max_points,
+            parameter_name="max_points",
+        )
+        metadata_copy = dict(metadata) if metadata is not None else None
+        return self.gateway.extract_points(
+            pipeline_input,
+            max_points=effective_limit,
+            metadata=metadata_copy,
+        )
+
+
+@dataclass(slots=True)
+class QueryBuildingService:
+    """Coordinates calls to the :class:`QueryBuilderGateway`.
+
+    Similar to :class:`ExtractionService`, this service enforces lightweight
+    validation and default handling before delegating to the gateway. Keeping the
+    logic concentrated here simplifies testing and ensures presentation code can
+    remain thin.
+    """
+
+    gateway: QueryBuilderGateway
+    default_max_queries: Optional[int] = None
+
+    def run(
+        self,
+        extraction: ExtractionResult,
+        pipeline_input: Optional[PipelineInput] = None,
+        *,
+        max_queries: Optional[int] = None,
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> QueryPlan:
+        """Execute the query building workflow.
+
+        Args:
+            extraction: Structured extraction result that contains the points used
+                for planning queries.
+            pipeline_input: Optional original corpus to supply extra context to
+                the gateway.
+            max_queries: Optional override for limiting the number of queries.
+            metadata: Optional mapping of contextual hints. A defensive copy is
+                passed to downstream components to avoid shared mutation.
+
+        Returns:
+            Query plan produced by the gateway.
+
+        Raises:
+            ValueError: If ``max_queries`` is provided but not positive.
+            RuntimeError: Propagated from the gateway implementation.
+
+        Side Effects:
+            The gateway may interact with external providers or record
+            observability data.
+
+        Timeout:
+            Determined by the gateway or caller-supplied wrappers.
+        """
+
+        effective_limit = _validate_limit(
+            max_queries if max_queries is not None else self.default_max_queries,
+            parameter_name="max_queries",
+        )
+        metadata_copy = dict(metadata) if metadata is not None else None
+        return self.gateway.build_queries(
+            extraction,
+            pipeline_input,
+            max_queries=effective_limit,
+            metadata=metadata_copy,
+        )
+
+
+__all__ = ["ExtractionService", "QueryBuildingService"]

--- a/src/contexts/schemas/extraction.schema.json
+++ b/src/contexts/schemas/extraction.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cogito.ai/schemas/preflight/extraction.schema.json",
+  "title": "ExtractionResult",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["points", "source_stats", "truncated"],
+  "properties": {
+    "points": {
+      "type": "array",
+      "description": "Ordered list of extracted points ranked by relevance.",
+      "items": {
+        "$ref": "#/$defs/extracted_point"
+      }
+    },
+    "source_stats": {
+      "type": "object",
+      "description": "Metadata describing the analysed corpus and extraction run.",
+      "additionalProperties": true
+    },
+    "truncated": {
+      "type": "boolean",
+      "description": "Whether the extractor truncated points due to caps or token limits."
+    }
+  },
+  "$defs": {
+    "extracted_point": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "title",
+        "summary",
+        "evidence_refs",
+        "confidence"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable identifier for the point."
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Concise heading describing the point."
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Multi-sentence summary elaborating on the point."
+        },
+        "evidence_refs": {
+          "type": "array",
+          "description": "References supporting the point (paths, citations, etc.).",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0,
+          "description": "Normalised confidence score between 0.0 and 1.0."
+        },
+        "tags": {
+          "type": "array",
+          "description": "Optional thematic tags assigned to the point.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        }
+      }
+    }
+  }
+}

--- a/src/contexts/schemas/query_plan.schema.json
+++ b/src/contexts/schemas/query_plan.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cogito.ai/schemas/preflight/query_plan.schema.json",
+  "title": "QueryPlan",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["queries", "rationale"],
+  "properties": {
+    "queries": {
+      "type": "array",
+      "description": "Ordered list of follow-up queries to execute.",
+      "items": {
+        "$ref": "#/$defs/built_query"
+      }
+    },
+    "rationale": {
+      "type": "string",
+      "description": "Overall strategy behind the query plan.",
+      "default": ""
+    },
+    "assumptions": {
+      "type": "array",
+      "description": "Optional assumptions that informed the plan.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": []
+    },
+    "risks": {
+      "type": "array",
+      "description": "Optional risks associated with the plan.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": []
+    }
+  },
+  "$defs": {
+    "built_query": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "text",
+        "purpose",
+        "priority"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable identifier for the query."
+        },
+        "text": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Natural language query text."
+        },
+        "purpose": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Explanation of why the query is needed."
+        },
+        "priority": {
+          "type": "integer",
+          "description": "Execution priority where lower numbers run earlier."
+        },
+        "depends_on_ids": {
+          "type": "array",
+          "description": "Identifiers of prerequisite queries.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "target_audience": {
+          "type": ["string", "null"],
+          "description": "Intended respondent or system for the query."
+        },
+        "suggested_tooling": {
+          "type": "array",
+          "description": "Preferred tooling identifiers to satisfy the query.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        }
+      }
+    }
+  }
+}

--- a/src/domain/preflight/__init__.py
+++ b/src/domain/preflight/__init__.py
@@ -1,0 +1,5 @@
+"""Preflight domain models package."""
+
+from .models import BuiltQuery, ExtractedPoint, ExtractionResult, QueryPlan
+
+__all__ = ["BuiltQuery", "ExtractedPoint", "ExtractionResult", "QueryPlan"]

--- a/src/domain/preflight/models.py
+++ b/src/domain/preflight/models.py
@@ -1,0 +1,153 @@
+"""Domain models for preflight extraction and query planning artifacts.
+
+Purpose:
+    Provide immutable data structures describing the outcomes of preflight
+    extraction and query planning workflows. The models are intentionally
+    lightweight and independent from framework code so they can be reused across
+    the application, presentation, and infrastructure layers without creating
+    dependency cycles.
+External Dependencies:
+    Python standard library modules ``dataclasses`` and ``typing`` only.
+Fallback Semantics:
+    Domain objects may capture fallback metadata such as raw provider responses
+    and validation error messages so that application services can continue
+    operating even when strict validation fails. They do not implement fallback
+    logic themselves.
+Timeout Strategy:
+    Not applicable. Domain objects do not manage or enforce timeout policies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class ExtractedPoint:
+    """Represents a salient point identified during preflight extraction.
+
+    Attributes:
+        id: Stable identifier that allows points to be referenced by later
+            processing stages. Implementations should prefer deterministic
+            identifiers such as UUIDs or hashes derived from the source
+            artefacts.
+        title: Human-readable heading summarising the point.
+        summary: Multi-sentence narrative expanding on the title and providing
+            sufficient context for downstream processing steps.
+        evidence_refs: Collection of references (for example file paths or
+            citation anchors) that support the point.
+        confidence: Normalised score in the ``[0.0, 1.0]`` range expressing the
+            extractor's certainty about the point's accuracy and relevance.
+        tags: Optional thematic labels applied by the extractor. Tags enable
+            filtering and prioritisation when building follow-up queries.
+
+    Raises:
+        ValueError: If ``confidence`` falls outside the inclusive ``[0.0, 1.0]``
+            interval.
+    """
+
+    id: str
+    title: str
+    summary: str
+    evidence_refs: Tuple[str, ...] = field(default_factory=tuple)
+    confidence: float = 0.0
+    tags: Tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        """Validate invariants defined for extracted points.
+
+        Raises:
+            ValueError: If the configured ``confidence`` is not normalised to the
+                ``[0.0, 1.0]`` range.
+        """
+
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be a normalised value between 0.0 and 1.0")
+
+
+@dataclass(frozen=True)
+class ExtractionResult:
+    """Container aggregating the results of a point extraction run.
+
+    Attributes:
+        points: Ordered collection of :class:`ExtractedPoint` instances emitted by
+            the extractor.
+        source_stats: Optional metadata describing the processed corpus such as
+            byte counts, token usage, or truncation markers. Downstream services
+            may use these statistics for observability and to inform retries.
+        truncated: Flag indicating whether the extractor truncated points due to
+            limits like ``max_points`` or model token caps.
+        raw_response: Optional raw JSON string returned by the provider when
+            validation failed and a fallback artefact had to be generated.
+        validation_errors: Tuple of formatted validation error messages used to
+            describe why structured parsing failed. An empty tuple indicates that
+            the result satisfied schema validation.
+    """
+
+    points: Tuple[ExtractedPoint, ...] = field(default_factory=tuple)
+    source_stats: Mapping[str, Any] = field(default_factory=dict)
+    truncated: bool = False
+    raw_response: Optional[str] = None
+    validation_errors: Tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class BuiltQuery:
+    """Represents a follow-up query derived from extracted points.
+
+    Attributes:
+        id: Stable identifier for referencing the query in dependency graphs.
+        text: Natural-language query or instruction to be executed during later
+            stages.
+        purpose: Short description capturing why the query is necessary.
+        priority: Integer representing the execution order preference. Lower
+            numbers can represent higher priority depending on orchestration
+            policy.
+        depends_on_ids: Identifiers of prerequisite queries that must complete
+            before this query executes.
+        target_audience: Optional descriptor indicating the intended responder
+            (for example ``"author"``, ``"reviewer"`` or a specific tool name).
+        suggested_tooling: Optional set of tool identifiers that best suit the
+            query. The field supports multiple suggestions to allow fallbacks.
+    """
+
+    id: str
+    text: str
+    purpose: str
+    priority: int
+    depends_on_ids: Tuple[str, ...] = field(default_factory=tuple)
+    target_audience: Optional[str] = None
+    suggested_tooling: Tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class QueryPlan:
+    """Aggregates all queries and related context for downstream orchestration.
+
+    Attributes:
+        queries: Ordered collection of :class:`BuiltQuery` items that form the
+            plan.
+        rationale: Narrative description of the strategy behind the plan.
+        assumptions: Optional list of assumptions that influenced the plan.
+        risks: Optional list describing potential pitfalls or uncertainties.
+        raw_response: Optional raw JSON string captured when validation failed
+            but the application chose to continue with a fallback artefact.
+        validation_errors: Tuple of formatted validation error messages. An empty
+            tuple signals that the plan passed validation successfully.
+    """
+
+    queries: Tuple[BuiltQuery, ...] = field(default_factory=tuple)
+    rationale: str = ""
+    assumptions: Tuple[str, ...] = field(default_factory=tuple)
+    risks: Tuple[str, ...] = field(default_factory=tuple)
+    raw_response: Optional[str] = None
+    validation_errors: Tuple[str, ...] = field(default_factory=tuple)
+
+
+__all__ = [
+    "BuiltQuery",
+    "ExtractedPoint",
+    "ExtractionResult",
+    "QueryPlan",
+]

--- a/src/infrastructure/preflight/__init__.py
+++ b/src/infrastructure/preflight/__init__.py
@@ -1,0 +1,23 @@
+"""Infrastructure adapters for preflight extraction and query planning.
+
+Purpose:
+    Provide provider-specific gateway implementations that bridge the
+    application layer's ports to concrete language model clients. The
+    adapters coordinate prompt construction, provider invocation, and
+    structured parsing so outer layers can depend on stable abstractions.
+External Dependencies:
+    Relies on the OpenAI provider client housed in ``src.providers`` and the
+    clean application-layer utilities for prompts and parsing.
+Fallback Semantics:
+    When provider responses fail validation the adapters return fallback
+    domain objects populated with the raw provider response and formatted
+    validation errors, allowing callers to continue while flagging the
+    issues.
+Timeout Strategy:
+    Delegates timeout enforcement to the shared ``operation_timeout`` context
+    manager sourced from :mod:`src.infrastructure.timeouts`.
+"""
+
+from .openai_gateway import OpenAIPointExtractorGateway, OpenAIQueryBuilderGateway
+
+__all__ = ["OpenAIPointExtractorGateway", "OpenAIQueryBuilderGateway"]

--- a/src/infrastructure/preflight/openai_gateway.py
+++ b/src/infrastructure/preflight/openai_gateway.py
@@ -1,0 +1,703 @@
+"""OpenAI gateway implementations for preflight extraction workflows.
+
+Purpose:
+    Bridge the application layer's preflight ports to the OpenAI provider
+    client. The adapters compose prompts, execute model calls with retries and
+    timeouts, and convert structured responses into immutable domain models.
+External Dependencies:
+    Relies on the OpenAI client housed in :mod:`src.providers.openai_client`
+    and parsing utilities from :mod:`src.application.preflight`.
+Fallback Semantics:
+    When validation fails the adapters return fallback domain objects emitted
+    by the parsers. These objects retain the raw provider response and
+    formatted validation errors so callers can persist diagnostic artefacts.
+Timeout Strategy:
+    Uses :func:`src.infrastructure.timeouts.operation_timeout` to enforce the
+    configured wall-clock timeout for each provider invocation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any, Callable, Mapping, Optional, Sequence, Tuple, TypeVar, Protocol
+
+from ...application.preflight.extraction_parser import ExtractionResponseParser
+from ...application.preflight.prompts import (
+    PromptBundle,
+    build_extraction_prompt,
+    build_query_plan_prompt,
+)
+from ...application.preflight.query_parser import QueryPlanResponseParser
+from ...application.preflight.schema_validation import (
+    StructuredParseResult,
+    ValidationIssue,
+)
+from ...application.preflight.schemas import (
+    load_extraction_schema,
+    load_query_plan_schema,
+)
+from ...application.preflight.ports import (
+    PointExtractorGateway,
+    QueryBuilderGateway,
+)
+from ...domain.preflight import ExtractionResult, QueryPlan
+from ...pipeline_input import PipelineInput
+from ...providers import openai_client
+from ..timeouts import TimeoutConfig, get_timeout_config, operation_timeout
+
+
+DEFAULT_PROVIDER_TIMEOUT_SECONDS = 60.0
+DEFAULT_MAX_OUTPUT_TOKENS = 4096
+
+
+JsonLike = Any
+ProviderCall = Callable[..., Tuple[JsonLike, str]]
+
+
+@dataclass(frozen=True)
+class OpenAIRequestPayload:
+    """Describe the parameters required to issue a single OpenAI request.
+
+    Attributes:
+        system_message: Instructional content supplied as the system message.
+        user_message: Main user prompt delivered to the model.
+        max_output_tokens: Optional cap for tokens emitted by the model.
+        temperature: Optional sampling temperature override.
+    """
+
+    system_message: str
+    user_message: str
+    max_output_tokens: Optional[int]
+    temperature: Optional[float]
+
+
+@dataclass(frozen=True)
+class OpenAIDefaults:
+    """Capture default OpenAI parameters resolved from configuration.
+
+    Attributes:
+        max_output_tokens: Optional fallback token cap for responses.
+        temperature: Optional fallback temperature used when overrides are
+            absent.
+    """
+
+    max_output_tokens: Optional[int]
+    temperature: Optional[float]
+
+
+ModelT = TypeVar("ModelT")
+
+
+class _ResponseParser(Protocol[ModelT]):
+    """Protocol describing the parser interface consumed by the gateways."""
+
+    def parse(self, raw_text: str) -> StructuredParseResult[ModelT]:
+        """Parse ``raw_text`` into a structured result."""
+
+    def build_retry_message(self, issues: Sequence[ValidationIssue]) -> str:
+        """Render ``issues`` into a guidance string for retries."""
+
+
+def _coerce_optional_int(value: Any) -> Optional[int]:
+    """Convert ``value`` to ``int`` when feasible.
+
+    Args:
+        value: Candidate value that may represent an integer.
+
+    Returns:
+        Normalised integer when conversion succeeds and the value is positive;
+        otherwise ``None``.
+
+    Raises:
+        None. Invalid inputs return ``None`` instead of raising exceptions.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; execution is CPU-bound.
+    """
+
+    if value is None:
+        return None
+    try:
+        converted = int(value)
+    except (TypeError, ValueError):
+        return None
+    if converted <= 0:
+        return None
+    return converted
+
+
+def _coerce_optional_float(value: Any) -> Optional[float]:
+    """Convert ``value`` to ``float`` when feasible.
+
+    Args:
+        value: Candidate numeric value.
+
+    Returns:
+        Float representation when conversion succeeds; otherwise ``None``.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; execution is CPU-bound.
+    """
+
+    if value is None:
+        return None
+    try:
+        converted = float(value)
+    except (TypeError, ValueError):
+        return None
+    return converted
+
+
+def _normalise_json_like(value: JsonLike) -> str:
+    """Serialise ``value`` to a JSON string when necessary.
+
+    Args:
+        value: Provider response payload that may already be a string or a
+            JSON-compatible object.
+
+    Returns:
+        Raw string representation suitable for downstream parsing.
+
+    Raises:
+        RuntimeError: If the provider returns an object that cannot be
+            serialised to JSON.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; execution is CPU-bound.
+    """
+
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except TypeError as exc:  # pragma: no cover - defensive branch
+        raise RuntimeError("Provider returned a non-serialisable payload") from exc
+
+
+def _compose_retry_prompt(base_prompt: str, retry_guidance: str) -> str:
+    """Append retry guidance to the original user prompt.
+
+    Args:
+        base_prompt: Original user prompt supplied to the provider.
+        retry_guidance: Additional instruction describing validation issues.
+
+    Returns:
+        Updated prompt instructing the model to correct prior validation
+        problems.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; execution is CPU-bound.
+    """
+
+    return f"{base_prompt}\n\n=== Retry Guidance ===\n{retry_guidance}\n"
+
+
+def _extract_override(
+    metadata: Optional[Mapping[str, Any]],
+    key: str,
+    coercer: Callable[[Any], Optional[Any]],
+) -> Optional[Any]:
+    """Resolve an override value from ``metadata`` using ``key``.
+
+    Args:
+        metadata: Optional metadata mapping passed to the gateway.
+        key: Override key to resolve (for example ``"max_output_tokens"``).
+        coercer: Callable that normalises the resolved value.
+
+    Returns:
+        Normalised override when present; otherwise ``None``.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; execution is CPU-bound.
+    """
+
+    if metadata is None or not isinstance(metadata, Mapping):
+        return None
+    if key in metadata:
+        value = coercer(metadata[key])
+        if value is not None:
+            return value
+    provider_overrides = metadata.get("provider_overrides")
+    if isinstance(provider_overrides, Mapping) and key in provider_overrides:
+        return coercer(provider_overrides[key])
+    return None
+
+
+def _read_openai_defaults(config: Mapping[str, Any]) -> OpenAIDefaults:
+    """Extract default OpenAI parameters from ``config``.
+
+    Args:
+        config: Application configuration mapping.
+
+    Returns:
+        :class:`OpenAIDefaults` containing fallback token and temperature
+        values.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; execution is CPU-bound.
+    """
+
+    api_section = config.get("api", {}) if isinstance(config, Mapping) else {}
+    if not isinstance(api_section, Mapping):
+        api_section = {}
+    openai_config = api_section.get("openai", {})
+    if not isinstance(openai_config, Mapping):
+        openai_config = {}
+
+    max_tokens = _coerce_optional_int(openai_config.get("max_tokens"))
+    if max_tokens is None:
+        max_tokens = DEFAULT_MAX_OUTPUT_TOKENS
+    temperature = _coerce_optional_float(openai_config.get("temperature"))
+    if temperature is None:
+        temperature = 0.2
+    return OpenAIDefaults(max_output_tokens=max_tokens, temperature=temperature)
+
+
+class _OpenAIPreflightGatewayBase:
+    """Common functionality shared by OpenAI-backed preflight gateways."""
+
+    def __init__(
+        self,
+        *,
+        config: Optional[Mapping[str, Any]],
+        call_model: ProviderCall,
+        max_retries: int,
+        timeout_scope: str,
+        default_total_timeout: Optional[float],
+        max_output_tokens: Optional[int],
+        temperature: Optional[float],
+    ) -> None:
+        """Initialise shared dependencies for the OpenAI gateways.
+
+        Args:
+            config: Optional application configuration mapping used to resolve
+                provider settings and timeouts.
+            call_model: Callable responsible for executing the OpenAI request.
+            max_retries: Maximum number of retries after the first attempt.
+            timeout_scope: Dot-delimited scope for looking up timeout config.
+            default_total_timeout: Fallback timeout when configuration omits a
+                value.
+            max_output_tokens: Optional override for the maximum tokens.
+            temperature: Optional override for the sampling temperature.
+
+        Raises:
+            ValueError: If ``max_retries`` is negative.
+
+        Side Effects:
+            Reads timeout settings from ``config``.
+
+        Timeout:
+            Not applicable; the constructor performs synchronous setup.
+        """
+
+        self._config: Mapping[str, Any] = dict(config or {})
+        if max_retries < 0:
+            raise ValueError("max_retries must be a non-negative integer")
+        self._call_model = call_model
+        self._max_retries = max_retries
+        defaults = _read_openai_defaults(self._config)
+        self._max_output_tokens = (
+            max_output_tokens if max_output_tokens is not None else defaults.max_output_tokens
+        )
+        self._temperature = temperature if temperature is not None else defaults.temperature
+        self._timeout_config: TimeoutConfig = get_timeout_config(
+            self._config,
+            scope=timeout_scope,
+            default_total_seconds=default_total_timeout,
+        )
+
+    def _prepare_request(
+        self,
+        *,
+        system_message: str,
+        user_message: str,
+        metadata: Optional[Mapping[str, Any]],
+    ) -> OpenAIRequestPayload:
+        """Build a request payload including overrides from ``metadata``.
+
+        Args:
+            system_message: System-level instruction for the provider.
+            user_message: User prompt delivered to the provider.
+            metadata: Optional mapping containing override hints.
+
+        Returns:
+            Instance of :class:`OpenAIRequestPayload` encapsulating the
+            resolved provider parameters.
+
+        Raises:
+            None.
+
+        Side Effects:
+            None.
+
+        Timeout:
+            Not applicable; execution is CPU-bound.
+        """
+
+        max_tokens = _extract_override(metadata, "max_output_tokens", _coerce_optional_int)
+        if max_tokens is None:
+            max_tokens = _extract_override(metadata, "max_tokens", _coerce_optional_int)
+        temperature = _extract_override(metadata, "temperature", _coerce_optional_float)
+        return OpenAIRequestPayload(
+            system_message=system_message,
+            user_message=user_message,
+            max_output_tokens=max_tokens if max_tokens is not None else self._max_output_tokens,
+            temperature=temperature if temperature is not None else self._temperature,
+        )
+
+    def _invoke_model(
+        self,
+        request: OpenAIRequestPayload,
+        *,
+        operation_name: str,
+    ) -> str:
+        """Execute the provider call and return the raw response text.
+
+        Args:
+            request: Prepared OpenAI request payload.
+            operation_name: Human-readable operation label used in timeout
+                error messages.
+
+        Returns:
+            Raw string returned by the provider after serialisation.
+
+        Raises:
+            TimeoutError: When the provider call exceeds the configured
+                timeout.
+
+        Side Effects:
+            Issues HTTP requests via the provider client.
+
+        Timeout:
+            Enforced via :func:`operation_timeout` using the configured
+            :class:`TimeoutConfig`.
+        """
+
+        kwargs: dict[str, Any] = {}
+        if request.max_output_tokens is not None:
+            kwargs["max_tokens"] = request.max_output_tokens
+        if request.temperature is not None:
+            kwargs["temperature"] = request.temperature
+        with operation_timeout(self._timeout_config, operation=operation_name):
+            response, _ = self._call_model(
+                prompt_template=request.user_message,
+                context={},
+                config=self._config,
+                is_structured=True,
+                system_message=request.system_message,
+                **kwargs,
+            )
+        return _normalise_json_like(response)
+
+    def _execute_with_retries(
+        self,
+        *,
+        system_message: str,
+        user_message: str,
+        parser: _ResponseParser[ModelT],
+        metadata: Optional[Mapping[str, Any]],
+        operation_name: str,
+    ) -> ModelT:
+        """Perform the model call with validation-aware retries.
+
+        Args:
+            system_message: System prompt used for the request.
+            user_message: Base user prompt for the first attempt.
+            parser: Parser responsible for validating provider output.
+            metadata: Optional override metadata for provider parameters.
+            operation_name: Human-readable operation identifier.
+
+        Returns:
+            Parsed domain model or fallback artefact emitted by the parser.
+
+        Raises:
+            RuntimeError: If the parser fails to return a fallback artefact
+                after exhausting retries.
+
+        Side Effects:
+            Issues up to ``max_retries + 1`` provider calls.
+
+        Timeout:
+            Each provider call is wrapped in :func:`operation_timeout`.
+        """
+
+        prompt = user_message
+        fallback: Optional[ModelT] = None
+        issues: Sequence[ValidationIssue] = ()
+        for attempt in range(self._max_retries + 1):
+            request = self._prepare_request(
+                system_message=system_message,
+                user_message=prompt,
+                metadata=metadata,
+            )
+            raw_text = self._invoke_model(request, operation_name=operation_name)
+            result = parser.parse(raw_text)
+            if result.model is not None:
+                fallback = result.model
+            if result.is_valid:
+                assert result.model is not None
+                return result.model
+            issues = result.validation_errors
+            if attempt >= self._max_retries:
+                break
+            retry_message = parser.build_retry_message(issues)
+            prompt = _compose_retry_prompt(user_message, retry_message)
+        if fallback is None:
+            raise RuntimeError("Parser did not return a fallback model after retries.")
+        return fallback
+
+
+class OpenAIPointExtractorGateway(_OpenAIPreflightGatewayBase, PointExtractorGateway):
+    """OpenAI-backed implementation of :class:`PointExtractorGateway`.
+
+    The gateway composes prompts using the application-layer helpers,
+    executes OpenAI calls with timeout and retry controls, and converts
+    responses into immutable domain models via
+    :class:`ExtractionResponseParser`.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: Optional[Mapping[str, Any]] = None,
+        parser: Optional[ExtractionResponseParser] = None,
+        call_model: ProviderCall = openai_client.call_openai_with_retry,
+        prompt_builder: Callable[..., PromptBundle] = build_extraction_prompt,
+        schema_loader: Callable[[], Mapping[str, Any]] = load_extraction_schema,
+        max_retries: int = 1,
+        max_output_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        default_total_timeout: Optional[float] = DEFAULT_PROVIDER_TIMEOUT_SECONDS,
+    ) -> None:
+        """Configure the gateway with prompt builders, parser, and settings.
+
+        Args:
+            config: Optional configuration mapping forwarded to the provider
+                client and timeout helpers.
+            parser: Optional custom parser used to validate extraction
+                responses.
+            call_model: Callable executing the provider request.
+            prompt_builder: Callable that composes prompts for the model.
+            schema_loader: Callable returning the JSON schema mapping.
+            max_retries: Number of retry attempts on validation failure.
+            max_output_tokens: Optional override for the response token cap.
+            temperature: Optional override for the sampling temperature.
+            default_total_timeout: Fallback timeout when configuration omits
+                a value.
+
+        Raises:
+            ValueError: Propagated from the base class when ``max_retries`` is
+                negative.
+
+        Side Effects:
+            None beyond reading configuration data.
+
+        Timeout:
+            Not applicable; the constructor performs synchronous setup.
+        """
+
+        super().__init__(
+            config=config,
+            call_model=call_model,
+            max_retries=max_retries,
+            timeout_scope="preflight.extraction",
+            default_total_timeout=default_total_timeout,
+            max_output_tokens=max_output_tokens,
+            temperature=temperature,
+        )
+        self._parser = parser or ExtractionResponseParser()
+        self._prompt_builder = prompt_builder
+        self._schema_loader = schema_loader
+
+    def extract_points(
+        self,
+        pipeline_input: PipelineInput,
+        *,
+        max_points: Optional[int] = None,
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> ExtractionResult:
+        """Extract structured points from ``pipeline_input``.
+
+        Args:
+            pipeline_input: Canonical pipeline input for the run.
+            max_points: Optional limit for the number of points requested.
+            metadata: Optional mapping carrying provider override hints and
+                contextual metadata.
+
+        Returns:
+            :class:`ExtractionResult` describing the extracted points or a
+            fallback artefact when validation fails.
+
+        Raises:
+            TimeoutError: Propagated when the provider exceeds the configured
+                timeout.
+            RuntimeError: Propagated if retries complete without producing a
+                fallback artefact, which signals a deeper parser error.
+
+        Side Effects:
+            Issues OpenAI API calls and records timeout handlers during those
+            invocations.
+
+        Timeout:
+            Enforced per request using :func:`operation_timeout`.
+        """
+
+        schema = self._schema_loader()
+        prompt_bundle = self._prompt_builder(
+            pipeline_input,
+            schema,
+            max_points=max_points,
+        )
+        metadata_copy = dict(metadata) if metadata is not None else None
+        return self._execute_with_retries(
+            system_message=prompt_bundle.system,
+            user_message=prompt_bundle.user,
+            parser=self._parser,
+            metadata=metadata_copy,
+            operation_name="preflight_extraction",
+        )
+
+
+class OpenAIQueryBuilderGateway(_OpenAIPreflightGatewayBase, QueryBuilderGateway):
+    """OpenAI-backed implementation of :class:`QueryBuilderGateway`.
+
+    The adapter reuses shared prompt builders and parsers to transform
+    extraction results into structured query plans while honouring timeout and
+    retry policies.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: Optional[Mapping[str, Any]] = None,
+        parser: Optional[QueryPlanResponseParser] = None,
+        call_model: ProviderCall = openai_client.call_openai_with_retry,
+        prompt_builder: Callable[..., PromptBundle] = build_query_plan_prompt,
+        schema_loader: Callable[[], Mapping[str, Any]] = load_query_plan_schema,
+        max_retries: int = 1,
+        max_output_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        default_total_timeout: Optional[float] = DEFAULT_PROVIDER_TIMEOUT_SECONDS,
+    ) -> None:
+        """Configure the query-building gateway dependencies and defaults.
+
+        Args:
+            config: Optional configuration mapping that supplies provider
+                defaults and timeout settings.
+            parser: Optional parser overriding the default query plan parser.
+            call_model: Callable that performs the provider invocation.
+            prompt_builder: Callable constructing the prompt bundle.
+            schema_loader: Callable returning the JSON schema mapping.
+            max_retries: Number of retry attempts when validation fails.
+            max_output_tokens: Optional override for provider token caps.
+            temperature: Optional override for the sampling temperature.
+            default_total_timeout: Fallback timeout when configuration omits
+                a value.
+
+        Raises:
+            ValueError: Propagated from the base class when ``max_retries`` is
+                negative.
+
+        Side Effects:
+            None beyond reading configuration data.
+
+        Timeout:
+            Not applicable; the constructor performs synchronous setup.
+        """
+
+        super().__init__(
+            config=config,
+            call_model=call_model,
+            max_retries=max_retries,
+            timeout_scope="preflight.query_planning",
+            default_total_timeout=default_total_timeout,
+            max_output_tokens=max_output_tokens,
+            temperature=temperature,
+        )
+        self._parser = parser or QueryPlanResponseParser()
+        self._prompt_builder = prompt_builder
+        self._schema_loader = schema_loader
+
+    def build_queries(
+        self,
+        extraction: ExtractionResult,
+        pipeline_input: Optional[PipelineInput] = None,
+        *,
+        max_queries: Optional[int] = None,
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> QueryPlan:
+        """Build a query plan from ``extraction`` and optional ``pipeline_input``.
+
+        Args:
+            extraction: Extraction artefact containing the points to analyse.
+            pipeline_input: Optional original corpus to provide additional
+                context when planning queries.
+            max_queries: Optional cap on the number of queries to produce.
+            metadata: Optional mapping containing provider override hints.
+
+        Returns:
+            :class:`QueryPlan` describing the planned follow-up queries or a
+            fallback plan when validation fails.
+
+        Raises:
+            TimeoutError: If the provider call exceeds the configured timeout.
+            RuntimeError: When retries conclude without a fallback artefact,
+                indicating an internal parsing error.
+
+        Side Effects:
+            Issues OpenAI API requests and temporarily installs timeout
+            handlers.
+
+        Timeout:
+            Managed per request via :func:`operation_timeout`.
+        """
+
+        schema = self._schema_loader()
+        prompt_bundle = self._prompt_builder(
+            extraction,
+            schema,
+            pipeline_input=pipeline_input,
+            max_queries=max_queries,
+        )
+        metadata_copy = dict(metadata) if metadata is not None else None
+        return self._execute_with_retries(
+            system_message=prompt_bundle.system,
+            user_message=prompt_bundle.user,
+            parser=self._parser,
+            metadata=metadata_copy,
+            operation_name="preflight_query_planning",
+        )
+
+
+__all__ = ["OpenAIPointExtractorGateway", "OpenAIQueryBuilderGateway"]

--- a/src/infrastructure/timeouts.py
+++ b/src/infrastructure/timeouts.py
@@ -1,0 +1,162 @@
+"""Shared timeout helpers for infrastructure-level integrations.
+
+Purpose:
+    Offer reusable utilities for retrieving timeout configuration and
+    enforcing execution limits around blocking operations. The module keeps
+    timeout policies centralised so adapters can honour user preferences while
+    remaining framework-agnostic.
+External Dependencies:
+    Python standard library only (``contextlib``, ``dataclasses``, ``signal``,
+    and ``threading``).
+Fallback Semantics:
+    When timeout values are absent the helpers degrade gracefully by yielding
+    without enforcing limits, ensuring existing code paths continue to work.
+Timeout Strategy:
+    Implements wall-clock timeouts using ``signal.setitimer`` on the main
+    thread. When signals are unavailable the context manager becomes a no-op.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+import signal
+import threading
+from typing import Any, Generator, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class TimeoutConfig:
+    """Structured timeout configuration for blocking operations.
+
+    Attributes:
+        total_seconds: Optional overall timeout applied to the wrapped
+            operation. When ``None`` or non-positive, the timeout is disabled.
+        start_timeout_seconds: Optional timeout for initial response or
+            handshake phases. The current implementation does not enforce this
+            value but records it for future streaming integrations.
+    """
+
+    total_seconds: Optional[float] = None
+    start_timeout_seconds: Optional[float] = None
+
+
+def _follow_scope(mapping: Mapping[str, Any], scope: str) -> Mapping[str, Any]:
+    """Return the nested mapping referenced by ``scope`` within ``mapping``."""
+
+    current: Mapping[str, Any] = mapping
+    for part in scope.split("."):
+        candidate = current.get(part, {}) if isinstance(current, Mapping) else {}
+        if not isinstance(candidate, Mapping):
+            return {}
+        current = candidate
+    return current
+
+
+def _coerce_optional_float(value: Any) -> Optional[float]:
+    """Convert ``value`` to ``float`` when possible."""
+
+    if value is None:
+        return None
+    try:
+        converted = float(value)
+    except (TypeError, ValueError):
+        return None
+    if converted <= 0:
+        return None
+    return converted
+
+
+def get_timeout_config(
+    config: Optional[Mapping[str, Any]],
+    *,
+    scope: str,
+    default_total_seconds: Optional[float] = None,
+) -> TimeoutConfig:
+    """Extract timeout settings for the specified ``scope``.
+
+    Args:
+        config: Optional configuration mapping that may contain a ``timeouts``
+            section describing per-scope limits.
+        scope: Dot-delimited path resolving to the desired timeout settings
+            (for example ``"preflight.extraction"``).
+        default_total_seconds: Optional fallback total timeout applied when the
+            configuration omits an explicit value.
+
+    Returns:
+        :class:`TimeoutConfig` populated with the resolved timeout values. When
+        no values are configured the defaults are returned.
+
+    Raises:
+        None. Invalid or missing configuration entries are treated as absent
+        values.
+
+    Side Effects:
+        None. The function only inspects the provided mapping.
+
+    Timeout:
+        Not applicable; execution performs deterministic mapping lookups.
+    """
+
+    config_map: Mapping[str, Any] = config or {}
+    timeouts_section = config_map.get("timeouts", {})
+    if not isinstance(timeouts_section, Mapping):
+        timeouts_section = {}
+
+    scoped = _follow_scope(timeouts_section, scope)
+    total = _coerce_optional_float(scoped.get("total_seconds"))
+    start = _coerce_optional_float(scoped.get("start_seconds"))
+
+    if total is None:
+        total = _coerce_optional_float(default_total_seconds)
+
+    return TimeoutConfig(total_seconds=total, start_timeout_seconds=start)
+
+
+@contextmanager
+def operation_timeout(config: TimeoutConfig, *, operation: str) -> Generator[None, None, None]:
+    """Enforce the supplied timeout around a blocking operation.
+
+    Args:
+        config: Timeout parameters retrieved via :func:`get_timeout_config`.
+        operation: Human-readable operation name included in timeout errors.
+
+    Yields:
+        ``None`` while the wrapped block executes.
+
+    Raises:
+        TimeoutError: When the operation exceeds ``config.total_seconds``.
+
+    Side Effects:
+        Installs a temporary signal handler when the timeout is active.
+
+    Timeout:
+        Managed internally using :func:`signal.setitimer` on the main thread.
+    """
+
+    total_seconds = config.total_seconds
+    if total_seconds is None:
+        yield
+        return
+
+    if threading.current_thread() is not threading.main_thread():
+        # Signal-based timers only work reliably on the main thread; degrade to no-op.
+        yield
+        return
+
+    def _timeout_handler(_: int, __: Optional[object]) -> None:
+        raise TimeoutError(
+            f"Operation '{operation}' exceeded timeout of {total_seconds} seconds."
+        )
+
+    previous_handler = signal.getsignal(signal.SIGALRM)
+    try:
+        signal.signal(signal.SIGALRM, _timeout_handler)
+        signal.setitimer(signal.ITIMER_REAL, total_seconds)
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0.0)
+        signal.signal(signal.SIGALRM, previous_handler)
+
+
+__all__ = ["TimeoutConfig", "get_timeout_config", "operation_timeout"]

--- a/src/presentation/cli/preflight.py
+++ b/src/presentation/cli/preflight.py
@@ -1,0 +1,463 @@
+"""Utilities for CLI preflight configuration and artefact handling.
+
+Purpose:
+    Provide lightweight helpers that map configuration defaults and runtime
+    overrides into :class:`src.application.preflight.orchestrator.PreflightOptions`
+    instances and persist resulting artefacts to disk. The module keeps
+    presentation-layer parsing and persistence logic separate from the CLI
+    controller to maintain readability while respecting clean architecture
+    boundaries.
+External Dependencies:
+    Python standard library modules ``argparse``, ``dataclasses``, ``json``,
+    ``logging``, and ``pathlib`` only.
+Fallback Semantics:
+    When configuration values are missing or invalid, the helpers fall back to
+    conservative defaults that disable preflight stages until explicitly
+    enabled by the user.
+Timeout Strategy:
+    Not applicable. All functions perform deterministic, CPU-bound
+    transformations without I/O.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, Mapping, Optional
+
+from ...application.preflight.orchestrator import PreflightOptions, PreflightRunResult
+
+
+def _coerce_optional_int(value: Any) -> Optional[int]:
+    """Attempt to convert ``value`` into a positive integer.
+
+    Args:
+        value: Potential integer-like value supplied via configuration or CLI
+            overrides.
+
+    Returns:
+        ``None`` when ``value`` is ``None`` or cannot be converted. Otherwise,
+        returns the integer when positive. Non-positive integers are treated as
+        missing values.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; the function executes synchronously without I/O.
+    """
+
+    if value is None:
+        return None
+    try:
+        converted = int(value)
+    except (TypeError, ValueError):
+        return None
+    if converted <= 0:
+        return None
+    return converted
+
+
+def _safe_mapping(value: Any) -> Mapping[str, Any]:
+    """Return ``value`` when it is a mapping, otherwise an empty dict.
+
+    Args:
+        value: Candidate object that may represent a mapping.
+
+    Returns:
+        A shallow copy of ``value`` when it implements the mapping protocol,
+        otherwise an empty dictionary.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable.
+    """
+
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+@dataclass(frozen=True)
+class PreflightCliDefaults:
+    """Immutable configuration defaults used by the CLI when building options.
+
+    Attributes:
+        provider: Name of the provider configured for preflight stages.
+        extract_enabled: Whether extraction runs when the user does not supply
+            explicit overrides.
+        query_enabled: Whether query planning runs when overrides are absent.
+        max_points: Optional default limit for extracted points.
+        max_queries: Optional default limit for planned queries.
+        points_artifact: Relative path for storing extraction artefacts.
+        queries_artifact: Relative path for storing query plan artefacts.
+        metadata: Mapping propagated to the orchestrator for observability.
+    """
+
+    provider: str = "openai"
+    extract_enabled: bool = False
+    query_enabled: bool = False
+    max_points: Optional[int] = None
+    max_queries: Optional[int] = None
+    points_artifact: str = "artifacts/points.json"
+    queries_artifact: str = "artifacts/queries.json"
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PreflightCliOverrides:
+    """Container describing CLI-supplied overrides for preflight settings.
+
+    Attributes:
+        enable_extraction: Optional boolean override for enabling extraction.
+        enable_query_building: Optional boolean override controlling query
+            planning.
+        points_artifact: Optional path override for the extraction artefact.
+        queries_artifact: Optional path override for the query plan artefact.
+        max_points: Optional override for the extraction point limit.
+        max_queries: Optional override for the query plan limit.
+    """
+
+    enable_extraction: Optional[bool] = None
+    enable_query_building: Optional[bool] = None
+    points_artifact: Optional[str] = None
+    queries_artifact: Optional[str] = None
+    max_points: Optional[int] = None
+    max_queries: Optional[int] = None
+
+    @classmethod
+    def from_namespace(cls, args: argparse.Namespace | None) -> "PreflightCliOverrides":
+        """Create overrides from the parsed CLI namespace.
+
+        Args:
+            args: Parsed namespace produced by :mod:`argparse`. ``None`` yields
+                a default instance with no overrides.
+
+        Returns:
+            Populated :class:`PreflightCliOverrides` representing CLI
+            preferences.
+
+        Raises:
+            None.
+
+        Side Effects:
+            None.
+
+        Timeout:
+            Not applicable.
+        """
+
+        if args is None:
+            return cls()
+
+        return cls(
+            enable_extraction=getattr(args, "preflight_extract", None),
+            enable_query_building=getattr(args, "preflight_build_queries", None),
+            points_artifact=getattr(args, "points_out", None),
+            queries_artifact=getattr(args, "queries_out", None),
+            max_points=_coerce_optional_int(getattr(args, "max_points", None)),
+            max_queries=_coerce_optional_int(getattr(args, "max_queries", None)),
+        )
+
+
+def load_preflight_defaults(config: Mapping[str, Any]) -> PreflightCliDefaults:
+    """Extract CLI defaults for preflight stages from ``config``.
+
+    Args:
+        config: Mapping produced from ``config.json``.
+
+    Returns:
+        Instance of :class:`PreflightCliDefaults` populated with safe defaults.
+
+    Raises:
+        None. Invalid or missing entries fall back to conservative defaults.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; only dictionary lookups are performed.
+    """
+
+    preflight_section = _safe_mapping(config.get("preflight"))
+    extract_section = _safe_mapping(preflight_section.get("extract"))
+    query_section = _safe_mapping(preflight_section.get("queries"))
+
+    return PreflightCliDefaults(
+        provider=str(preflight_section.get("provider", "openai")),
+        extract_enabled=bool(extract_section.get("enabled", False)),
+        query_enabled=bool(query_section.get("enabled", False)),
+        max_points=_coerce_optional_int(extract_section.get("max_points")),
+        max_queries=_coerce_optional_int(query_section.get("max_queries")),
+        points_artifact=str(extract_section.get("artifact_path", "artifacts/points.json")),
+        queries_artifact=str(query_section.get("artifact_path", "artifacts/queries.json")),
+        metadata=_safe_mapping(preflight_section.get("metadata")),
+    )
+
+
+def build_preflight_options(
+    defaults: PreflightCliDefaults | None,
+    overrides: PreflightCliOverrides,
+) -> PreflightOptions | None:
+    """Merge defaults and overrides into :class:`PreflightOptions`.
+
+    Args:
+        defaults: Baseline configuration derived from ``config.json``. When
+            ``None``, preflight execution is disabled regardless of overrides.
+        overrides: CLI-supplied overrides parsed from runtime arguments.
+
+    Returns:
+        Populated :class:`PreflightOptions` when at least one stage is enabled;
+        otherwise ``None``.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable.
+    """
+
+    if defaults is None:
+        return None
+
+    enable_extraction = (
+        overrides.enable_extraction
+        if overrides.enable_extraction is not None
+        else defaults.extract_enabled
+    )
+    enable_query = (
+        overrides.enable_query_building
+        if overrides.enable_query_building is not None
+        else defaults.query_enabled
+    )
+
+    if enable_query and not enable_extraction:
+        enable_extraction = True
+
+    if not (enable_extraction or enable_query):
+        return None
+
+    max_points = overrides.max_points if overrides.max_points is not None else defaults.max_points
+    max_queries = (
+        overrides.max_queries if overrides.max_queries is not None else defaults.max_queries
+    )
+
+    metadata = dict(defaults.metadata)
+
+    return PreflightOptions(
+        enable_extraction=enable_extraction,
+        enable_query_building=enable_query,
+        max_points=max_points,
+        max_queries=max_queries,
+        metadata=metadata,
+        extraction_artifact_name=(
+            overrides.points_artifact if overrides.points_artifact else defaults.points_artifact
+        ),
+        query_artifact_name=(
+            overrides.queries_artifact if overrides.queries_artifact else defaults.queries_artifact
+        ),
+    )
+
+
+def _resolve_artifact_path(output_dir: Path, candidate: Optional[str], fallback: str) -> Path:
+    """Resolve an artefact path relative to ``output_dir`` when necessary.
+
+    Args:
+        output_dir: Directory where artefacts should be stored.
+        candidate: Optional candidate path supplied by the orchestrator.
+        fallback: Default relative path when ``candidate`` is ``None``.
+
+    Returns:
+        Absolute :class:`Path` pointing to the resolved location.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable.
+    """
+
+    name = candidate or fallback
+    path = Path(name)
+    if not path.is_absolute():
+        path = output_dir / path
+    return path
+
+
+def _write_json_payload(
+    path: Path,
+    payload: Mapping[str, Any],
+    *,
+    logger: logging.Logger,
+    description: str,
+) -> bool:
+    """Serialise ``payload`` as JSON and persist it to ``path``.
+
+    Args:
+        path: Destination file path for the artefact.
+        payload: Mapping that will be encoded as JSON.
+        logger: Logger capturing failures for diagnostics.
+        description: Human-readable artefact description for log messages.
+
+    Returns:
+        ``True`` when writing succeeds, otherwise ``False``.
+
+    Raises:
+        None.
+
+    Side Effects:
+        Creates parent directories when needed and writes files to disk.
+
+    Timeout:
+        Not applicable.
+    """
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.exception("Failed to prepare directory for %s", description)
+        return False
+    try:
+        path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    except OSError as exc:
+        logger.exception("Failed to write %s", description)
+        return False
+    return True
+
+
+def persist_preflight_artifacts(
+    preflight: PreflightRunResult,
+    output_dir: Path,
+    defaults: PreflightCliDefaults,
+    *,
+    logger: logging.Logger,
+    notify: Callable[[str], None],
+) -> Dict[str, str]:
+    """Persist preflight artefacts and return updated path mappings.
+
+    Args:
+        preflight: Orchestrator result containing extraction and query artefacts.
+        output_dir: Directory where artefacts should be written.
+        defaults: Default configuration controlling fallback artefact paths.
+        logger: Logger used to record failures during persistence.
+        notify: Callable used to surface success or failure messages to the user.
+
+    Returns:
+        Mapping of artefact keys to the absolute paths that were successfully
+        written. Entries are omitted when persistence fails.
+
+    Raises:
+        None. Failures are logged and surfaced via ``notify``.
+
+    Side Effects:
+        Writes JSON files to disk and emits user-facing notifications.
+
+    Timeout:
+        Not applicable; operations rely on the filesystem without explicit timeouts.
+    """
+
+    resolved: Dict[str, str] = {}
+
+    if preflight.extraction is not None:
+        path = _resolve_artifact_path(
+            output_dir,
+            preflight.artifact_paths.get("extraction"),
+            defaults.points_artifact,
+        )
+        if _write_json_payload(path, asdict(preflight.extraction), logger=logger, description="preflight extraction"):
+            notify(f"Preflight points saved to {path}")
+            resolved["extraction"] = str(path)
+        else:
+            notify(f"Warning: Could not write preflight extraction to {path}.")
+
+    if preflight.query_plan is not None:
+        path = _resolve_artifact_path(
+            output_dir,
+            preflight.artifact_paths.get("query_plan"),
+            defaults.queries_artifact,
+        )
+        if _write_json_payload(path, asdict(preflight.query_plan), logger=logger, description="preflight query plan"):
+            notify(f"Preflight queries saved to {path}")
+            resolved["query_plan"] = str(path)
+        else:
+            notify(f"Warning: Could not write preflight query plan to {path}.")
+
+    return resolved
+
+
+def update_preflight_metadata(
+    result: Any,
+    output_dir: Path,
+    defaults: PreflightCliDefaults,
+    *,
+    logger: logging.Logger,
+    notify: Callable[[str], None],
+) -> None:
+    """Persist artefacts and refresh metadata for a critique result.
+
+    Args:
+        result: Object with ``preflight`` and ``pipeline_input`` attributes
+            matching :class:`src.application.critique.services.CritiqueRunResult`.
+        output_dir: Directory where artefacts should be written.
+        defaults: Default CLI configuration for artefact handling.
+        logger: Logger used to record persistence issues.
+        notify: Callable used to display user-facing messages.
+
+    Returns:
+        None.
+
+    Raises:
+        None.
+
+    Side Effects:
+        Writes JSON artefacts and mutates the result's metadata mapping.
+
+    Timeout:
+        Not applicable.
+    """
+
+    preflight = getattr(result, "preflight", None)
+    if not isinstance(preflight, PreflightRunResult) or not preflight.has_outputs():
+        return
+
+    resolved_paths = persist_preflight_artifacts(
+        preflight,
+        output_dir,
+        defaults,
+        logger=logger,
+        notify=notify,
+    )
+    if resolved_paths:
+        preflight.artifact_paths.update(resolved_paths)
+
+    pipeline_input = getattr(result, "pipeline_input", None)
+    if pipeline_input is not None and hasattr(pipeline_input, "metadata"):
+        pipeline_input.metadata["preflight_artifacts"] = dict(preflight.artifact_paths)
+
+
+__all__ = [
+    "PreflightCliDefaults",
+    "PreflightCliOverrides",
+    "persist_preflight_artifacts",
+    "update_preflight_metadata",
+    "build_preflight_options",
+    "load_preflight_defaults",
+]
+

--- a/src/reasoning_tree.py
+++ b/src/reasoning_tree.py
@@ -5,7 +5,7 @@ Implements the recursive reasoning tree logic for critique generation.
 """
 
 import logging
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Optional, Sequence
 import uuid
 import json
 
@@ -18,6 +18,42 @@ DEFAULT_CONFIDENCE_THRESHOLD = 0.3
 
 module_logger = logging.getLogger(__name__)
 
+_DECOMPOSITION_TOPIC_KEYS: Sequence[str] = ("topics", "items", "subtopics")
+
+
+def _normalise_decomposition_topics(result: Any) -> tuple[List[str], Optional[Sequence[str]], Optional[str]]:
+    """Normalise decomposition payloads into a list of topic strings.
+
+    Args:
+        result: Raw object returned by the decomposition provider call.
+
+    Returns:
+        Tuple containing three values:
+            ``topics``: List of topic strings (may be empty when recursion should
+            stop).
+            ``observed_keys``: Sequence of keys seen when ``result`` is a mapping
+            that does not expose expected topic fields. ``None`` when not
+            applicable.
+            ``structure``: String describing the unexpected structure (for
+            example ``"list"``) when parsing fails. ``None`` when topics are
+            returned successfully.
+    """
+
+    if isinstance(result, list):
+        if all(isinstance(item, str) for item in result):
+            return list(result), None, None
+        return [], None, "list"
+
+    if isinstance(result, dict):
+        for key in _DECOMPOSITION_TOPIC_KEYS:
+            value = result.get(key)
+            if isinstance(value, list) and all(isinstance(item, str) for item in value):
+                return list(value), None, None
+        keys = tuple(sorted(str(item) for item in result.keys()))
+        return [], keys, "mapping"
+
+    return [], None, type(result).__name__
+
 # Synchronous version
 def execute_reasoning_tree(
     initial_content: str,
@@ -26,22 +62,36 @@ def execute_reasoning_tree(
     config: Dict[str, Any],
     agent_logger: Optional[logging.Logger] = None,
     depth: int = 0,
-    assigned_points: Optional[List[Dict[str, Any]]] = None
+    assigned_points: Optional[List[Dict[str, Any]]] = None,
+    *,
+    _warning_state: Optional[Dict[str, bool]] = None,
 ) -> Optional[Dict[str, Any]]:
-    """
-    Recursively generates a critique tree synchronously.
-    
+    """Recursively generate a reasoning tree for critique generation.
+
     Args:
-        initial_content: Content to critique
-        style_directives: Directives for the critique style
-        agent_style: Style identifier for the agent
-        config: Configuration settings
-        agent_logger: Optional logger to use
-        depth: Current depth in the reasoning tree
-        assigned_points: Optional list of points assigned to this agent
+        initial_content: Content to critique.
+        style_directives: Directives for the critique style.
+        agent_style: Style identifier for the agent.
+        config: Configuration settings and provider metadata.
+        agent_logger: Optional logger to use.
+        depth: Current depth in the reasoning tree.
+        assigned_points: Optional list of points assigned to this agent.
+        _warning_state: Internal mutable flag used to ensure decomposition
+            warnings emit at most once per run.
+
+    Returns:
+        Structured node describing the critique branch or ``None`` when the
+        branch terminates early.
+
+    Raises:
+        None. Provider exceptions are caught, logged, and result in branch
+        termination.
     """
+
     current_logger = agent_logger or module_logger
     current_logger.info(f"Depth {depth}: Starting analysis...")
+
+    warning_state = _warning_state if _warning_state is not None else {"emitted": False}
 
     tree_config = config.get('reasoning_tree', {})
     max_depth = tree_config.get('max_depth', DEFAULT_MAX_DEPTH)
@@ -138,8 +188,8 @@ Content Segment:
 {content}
 ```
 
-Return ONLY a JSON list of strings, where each string is a concise description of a sub-topic to analyze further. If no further decomposition is necessary or possible, return an empty list []. Example:
-["The definition of 'synergy' in paragraph 2", "The causality argument in section 3.1", "The empirical evidence cited for claim X"]
+Return a JSON object with a "topics" field containing an array of concise strings that describe each sub-topic to explore next. If "topics" is unavailable for your model, you may instead use "items" or "subtopics" with the same array-of-strings structure. When no additional decomposition is required, return an empty array for the selected field. Example:
+{{"topics": ["The definition of 'synergy' in paragraph 2", "The causality argument in section 3.1", "The empirical evidence cited for claim X"]}}
 """
     decomposition_context = {
         "claim": claim,
@@ -153,12 +203,31 @@ Return ONLY a JSON list of strings, where each string is a concise description o
             config=config,
             is_structured=True
         )
-        if isinstance(decomposition_result, list) and all(isinstance(item, str) for item in decomposition_result):
-            sub_topics_for_recursion = decomposition_result
-            current_logger.info(f"Depth {depth}: [Model: {model_used_for_decomposition}] Identified {len(sub_topics_for_recursion)} sub-topics for recursion.")
+        provider_name = (
+            config.get("api", {}).get("primary_provider")
+            if isinstance(config.get("api"), dict)
+            else None
+        ) or "unknown"
+        topics, observed_keys, structure_type = _normalise_decomposition_topics(decomposition_result)
+        if topics:
+            sub_topics_for_recursion = topics
+            current_logger.info(
+                f"Depth {depth}: [Model: {model_used_for_decomposition}] Identified {len(sub_topics_for_recursion)} sub-topics for recursion."
+            )
         else:
-            current_logger.warning(f"Depth {depth}: Unexpected decomposition structure received from {model_used_for_decomposition}: {decomposition_result}")
-            pass
+            if not warning_state["emitted"]:
+                keys_fragment = (
+                    ",".join(observed_keys) if observed_keys is not None else f"<{structure_type}>"
+                )
+                current_logger.warning(
+                    "Depth %d: Unexpected decomposition structure provider=%s model=%s keys=%s expected_keys=%s",
+                    depth,
+                    provider_name,
+                    model_used_for_decomposition,
+                    keys_fragment,
+                    "|".join(_DECOMPOSITION_TOPIC_KEYS),
+                )
+                warning_state["emitted"] = True
 
     except (ApiCallError, ApiResponseError, JsonParsingError, JsonProcessingError) as e:
         current_logger.error(f"Depth {depth}: Failed to identify decomposition points: {e}")
@@ -193,7 +262,8 @@ Return ONLY a JSON list of strings, where each string is a concise description o
                 config=config,
                 agent_logger=current_logger,
                 depth=depth + 1,
-                assigned_points=sub_assigned_points
+                assigned_points=sub_assigned_points,
+                _warning_state=warning_state
             )
             if child_node:
                 sub_critiques.append(child_node)

--- a/tests/application/preflight/test_orchestrator.py
+++ b/tests/application/preflight/test_orchestrator.py
@@ -1,0 +1,190 @@
+"""Tests for the preflight orchestrator sequencing extraction and query planning.
+
+Purpose:
+    Validate that :class:`PreflightOrchestrator` delegates to the extraction and
+    query building services according to the supplied options while capturing
+    artefact metadata.
+External Dependencies:
+    Uses ``pytest`` and standard library modules only, alongside project-local
+    application and domain packages.
+Fallback Semantics:
+    The tests rely on stub gateways that do not trigger fallback behaviours.
+Timeout Strategy:
+    No blocking operations are performed; timeouts are not exercised.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import pytest
+
+from src.application.preflight.orchestrator import PreflightOptions, PreflightOrchestrator
+from src.application.preflight.services import ExtractionService, QueryBuildingService
+from src.domain.preflight import BuiltQuery, ExtractedPoint, ExtractionResult, QueryPlan
+from src.pipeline_input import PipelineInput
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class _StubExtractorGateway:
+    """Record interactions from :class:`ExtractionService` for assertions."""
+
+    result: ExtractionResult
+    calls: List[Dict[str, object]]
+
+    def __init__(self, result: ExtractionResult) -> None:
+        self.result = result
+        self.calls = []
+
+    def extract_points(
+        self,
+        pipeline_input: PipelineInput,
+        *,
+        max_points: Optional[int] = None,
+        metadata: Optional[Dict[str, object]] = None,
+    ) -> ExtractionResult:
+        self.calls.append(
+            {
+                "input": pipeline_input,
+                "max_points": max_points,
+                "metadata": metadata,
+            }
+        )
+        return self.result
+
+
+@dataclass(slots=True)
+class _StubQueryGateway:
+    """Record interactions from :class:`QueryBuildingService` for assertions."""
+
+    result: QueryPlan
+    calls: List[Dict[str, object]]
+
+    def __init__(self, result: QueryPlan) -> None:
+        self.result = result
+        self.calls = []
+
+    def build_queries(
+        self,
+        extraction: ExtractionResult,
+        pipeline_input: Optional[PipelineInput] = None,
+        *,
+        max_queries: Optional[int] = None,
+        metadata: Optional[Dict[str, object]] = None,
+    ) -> QueryPlan:
+        self.calls.append(
+            {
+                "extraction": extraction,
+                "pipeline_input": pipeline_input,
+                "max_queries": max_queries,
+                "metadata": metadata,
+            }
+        )
+        return self.result
+
+
+def _build_extraction_result() -> ExtractionResult:
+    point = ExtractedPoint(
+        id="p1",
+        title="Point",
+        summary="Summary",
+        evidence_refs=("ref",),
+        confidence=0.9,
+        tags=("tag",),
+    )
+    return ExtractionResult(points=(point,))
+
+
+def _build_query_plan() -> QueryPlan:
+    query = BuiltQuery(
+        id="q1",
+        text="What next?",
+        purpose="Explore",
+        priority=1,
+        depends_on_ids=(),
+        target_audience=None,
+        suggested_tooling=(),
+    )
+    return QueryPlan(queries=(query,), rationale="Plan")
+
+
+def test_run_no_stages_returns_empty_result() -> None:
+    LOGGER.info("Ensuring orchestrator returns empty results when no stages are enabled.")
+    extractor = ExtractionService(gateway=_StubExtractorGateway(_build_extraction_result()))
+    query_builder = QueryBuildingService(gateway=_StubQueryGateway(_build_query_plan()))
+    orchestrator = PreflightOrchestrator(extractor, query_builder)
+    pipeline_input = PipelineInput(content="body")
+
+    result = orchestrator.run(pipeline_input, PreflightOptions())
+
+    assert result.extraction is None
+    assert result.query_plan is None
+    assert result.artifact_paths == {}
+
+
+def test_run_with_extraction_only() -> None:
+    LOGGER.info("Verifying extraction stage runs in isolation and registers default artefact path.")
+    extraction_result = _build_extraction_result()
+    extractor_gateway = _StubExtractorGateway(extraction_result)
+    extractor = ExtractionService(gateway=extractor_gateway)
+    query_builder = QueryBuildingService(gateway=_StubQueryGateway(_build_query_plan()))
+    orchestrator = PreflightOrchestrator(extractor, query_builder)
+    pipeline_input = PipelineInput(content="body")
+
+    options = PreflightOptions(enable_extraction=True, max_points=5)
+    result = orchestrator.run(pipeline_input, options)
+
+    assert result.extraction == extraction_result
+    assert result.query_plan is None
+    assert result.artifact_paths == {"extraction": "artifacts/points.json"}
+    assert extractor_gateway.calls[0]["max_points"] == 5
+    assert extractor_gateway.calls[0]["metadata"] is None
+
+
+def test_run_with_extraction_and_query_custom_paths() -> None:
+    LOGGER.info("Ensuring both stages execute and artefact paths honour custom configuration.")
+    extraction_result = _build_extraction_result()
+    query_plan = _build_query_plan()
+    extractor_gateway = _StubExtractorGateway(extraction_result)
+    query_gateway = _StubQueryGateway(query_plan)
+    extractor = ExtractionService(gateway=extractor_gateway)
+    query_builder = QueryBuildingService(gateway=query_gateway)
+    orchestrator = PreflightOrchestrator(extractor, query_builder)
+    pipeline_input = PipelineInput(content="body")
+
+    options = PreflightOptions(
+        enable_extraction=True,
+        enable_query_building=True,
+        max_points=2,
+        max_queries=3,
+        metadata={"run_id": "abc"},
+        extraction_artifact_name="artifacts/custom_points.json",
+        query_artifact_name="artifacts/custom_queries.json",
+    )
+    result = orchestrator.run(pipeline_input, options)
+
+    assert result.extraction == extraction_result
+    assert result.query_plan == query_plan
+    assert result.artifact_paths == {
+        "extraction": "artifacts/custom_points.json",
+        "query_plan": "artifacts/custom_queries.json",
+    }
+    assert extractor_gateway.calls[0]["metadata"] == {"run_id": "abc"}
+    assert query_gateway.calls[0]["max_queries"] == 3
+    assert query_gateway.calls[0]["metadata"] == {"run_id": "abc"}
+    assert query_gateway.calls[0]["extraction"] is extraction_result
+
+
+def test_run_raises_when_query_enabled_without_extraction() -> None:
+    LOGGER.info("Validating query building without extraction raises a configuration error.")
+    extractor = ExtractionService(gateway=_StubExtractorGateway(_build_extraction_result()))
+    query_builder = QueryBuildingService(gateway=_StubQueryGateway(_build_query_plan()))
+    orchestrator = PreflightOrchestrator(extractor, query_builder)
+    pipeline_input = PipelineInput(content="body")
+
+    with pytest.raises(ValueError):
+        orchestrator.run(pipeline_input, PreflightOptions(enable_query_building=True))

--- a/tests/application/preflight/test_parsers.py
+++ b/tests/application/preflight/test_parsers.py
@@ -1,0 +1,173 @@
+"""Parser validation tests for preflight extraction and query planning.
+
+Purpose:
+    Exercise the extraction and query plan parsers to ensure valid payloads
+    produce domain models while invalid payloads generate fallback artefacts with
+    structured validation feedback.
+External Dependencies:
+    Depends on project-local application and domain modules in addition to the
+    Python standard library.
+Fallback Semantics:
+    Tests cover fallback behaviour by asserting the presence of raw responses and
+    validation error messages when schema validation fails.
+Timeout Strategy:
+    Not applicable; parsing and validation are CPU-bound operations.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Sequence
+
+from src.application.preflight.extraction_parser import ExtractionResponseParser
+from src.application.preflight.query_parser import QueryPlanResponseParser
+from src.application.preflight.schema_validation import ValidationIssue
+from src.domain.preflight import ExtractionResult, QueryPlan
+
+
+def _valid_extraction_payload() -> dict[str, object]:
+    """Return a JSON-serialisable payload satisfying the extraction schema."""
+
+    return {
+        "points": [
+            {
+                "id": "alpha",
+                "title": "Alpha",
+                "summary": "Detailed summary",
+                "evidence_refs": ["doc:1"],
+                "confidence": 0.8,
+                "tags": ["tag"],
+            }
+        ],
+        "source_stats": {"chars": 1234},
+        "truncated": False,
+    }
+
+
+def _valid_query_plan_payload() -> dict[str, object]:
+    """Return a JSON-serialisable payload satisfying the query plan schema."""
+
+    return {
+        "queries": [
+            {
+                "id": "q1",
+                "text": "Investigate alpha",
+                "purpose": "Validate claim",
+                "priority": 1,
+                "depends_on_ids": ["seed"],
+                "target_audience": "reviewer",
+                "suggested_tooling": ["browser"],
+            }
+        ],
+        "rationale": "Follow-up necessary",
+        "assumptions": ["data is current"],
+        "risks": ["evidence sparse"],
+    }
+
+
+def test_extraction_parser_returns_valid_model() -> None:
+    """Ensure valid extraction payloads produce populated domain models."""
+
+    parser = ExtractionResponseParser()
+    payload = _valid_extraction_payload()
+    result = parser.parse(json.dumps(payload))
+
+    assert result.is_valid
+    assert isinstance(result.model, ExtractionResult)
+    assert result.model.points[0].id == "alpha"
+    assert result.model.source_stats == {"chars": 1234}
+    assert result.model.truncated is False
+
+
+def test_extraction_parser_reports_validation_errors_and_fallback() -> None:
+    """Verify invalid extraction payloads yield fallback artefacts with errors."""
+
+    parser = ExtractionResponseParser()
+    invalid_payload = json.dumps({"points": [], "source_stats": {}, "truncated": "no"})
+
+    result = parser.parse(invalid_payload)
+
+    assert not result.is_valid
+    assert result.validation_errors
+    assert isinstance(result.model, ExtractionResult)
+    assert result.model.raw_response == invalid_payload
+    assert result.model.validation_errors
+
+
+def test_extraction_retry_message_lists_issues() -> None:
+    """Ensure retry guidance enumerates validation issues with schema context."""
+
+    parser = ExtractionResponseParser()
+    issues: Sequence[ValidationIssue] = (
+        ValidationIssue(path=("points", "0", "title"), message="Missing required property."),
+    )
+
+    message = parser.build_retry_message(issues)
+
+    assert "extraction.schema.json" in message
+    assert "Missing required property" in message
+    assert message.endswith("Output only the corrected JSON with no extra commentary.")
+
+
+def test_extraction_retry_message_handles_successful_response() -> None:
+    """Ensure retry guidance explains that no issues remain when validation passes."""
+
+    parser = ExtractionResponseParser()
+
+    message = parser.build_retry_message(())
+
+    assert message == "Previous response was valid; no retry guidance necessary."
+
+
+def test_query_plan_parser_returns_valid_model() -> None:
+    """Ensure valid query plan payloads produce populated domain models."""
+
+    parser = QueryPlanResponseParser()
+    payload = _valid_query_plan_payload()
+    result = parser.parse(json.dumps(payload))
+
+    assert result.is_valid
+    assert isinstance(result.model, QueryPlan)
+    assert result.model.queries[0].id == "q1"
+    assert result.model.rationale == "Follow-up necessary"
+    assert result.model.assumptions == ("data is current",)
+
+
+def test_query_plan_parser_reports_validation_errors_and_fallback() -> None:
+    """Verify invalid query plans yield fallback artefacts with errors."""
+
+    parser = QueryPlanResponseParser()
+    invalid_payload = json.dumps({"queries": [], "rationale": 1})
+
+    result = parser.parse(invalid_payload)
+
+    assert not result.is_valid
+    assert result.validation_errors
+    assert isinstance(result.model, QueryPlan)
+    assert result.model.raw_response == invalid_payload
+    assert result.model.validation_errors
+
+
+def test_query_plan_retry_message_lists_issues() -> None:
+    """Ensure retry guidance enumerates validation issues with schema context."""
+
+    parser = QueryPlanResponseParser()
+    issues: Sequence[ValidationIssue] = (
+        ValidationIssue(path=("queries", "0", "priority"), message="priority must be an integer."),
+    )
+
+    message = parser.build_retry_message(issues)
+
+    assert "query_plan.schema.json" in message
+    assert "priority must be an integer" in message
+    assert message.endswith("Output only the corrected JSON with no additional commentary.")
+
+
+def test_query_plan_retry_message_handles_successful_response() -> None:
+    """Ensure retry guidance explains that no issues remain when validation passes."""
+
+    parser = QueryPlanResponseParser()
+
+    message = parser.build_retry_message(())
+
+    assert message == "Previous response was valid; no retry guidance necessary."

--- a/tests/application/preflight/test_prompts.py
+++ b/tests/application/preflight/test_prompts.py
@@ -1,0 +1,179 @@
+"""Prompt builder tests for preflight workflows.
+
+Purpose:
+    Validate that the extraction and query planning prompt builders emit the
+    required guardrails, schema instructions, and contextual metadata mandated by
+    the preflight checklist.
+External Dependencies:
+    Uses only project-local modules alongside Python's standard library.
+Fallback Semantics:
+    The tests verify pure string composition; no fallback logic is exercised.
+Timeout Strategy:
+    Not applicable. Prompt construction is CPU-bound and incurs no blocking I/O.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from src.application.preflight.prompts import (
+    PromptBundle,
+    build_extraction_prompt,
+    build_query_plan_prompt,
+)
+from src.domain.preflight import ExtractedPoint, ExtractionResult
+from src.pipeline_input import PipelineInput
+
+
+def _example_schema() -> Mapping[str, object]:
+    """Return a minimal JSON Schema snippet for prompt embedding.
+
+    Returns:
+        Mapping representing a bare-bones JSON Schema used to verify that the
+        prompt builders include schema content verbatim.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; the mapping is static.
+    """
+
+    return {
+        "title": "ExampleSchema",
+        "type": "object",
+        "properties": {
+            "items": {
+                "type": "array",
+                "items": {"type": "string"},
+            }
+        },
+        "required": ["items"],
+    }
+
+
+def _example_extraction_result() -> ExtractionResult:
+    """Build a deterministic extraction result for prompt formatting checks.
+
+    Returns:
+        An :class:`ExtractionResult` containing two :class:`ExtractedPoint`
+        instances to ensure the prompt formatting enumerates points correctly.
+
+    Raises:
+        None.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; the domain objects are created synchronously.
+    """
+
+    return ExtractionResult(
+        points=(
+            ExtractedPoint(
+                id="point-1",
+                title="Key Insight",
+                summary="Critical finding described in detail.",
+                evidence_refs=("doc:1",),
+                confidence=0.9,
+                tags=("safety",),
+            ),
+            ExtractedPoint(
+                id="point-2",
+                title="Secondary Insight",
+                summary="Supporting evidence captured here.",
+                evidence_refs=("doc:2", "doc:3"),
+                confidence=0.75,
+                tags=(),
+            ),
+        ),
+        truncated=True,
+    )
+
+
+def test_build_extraction_prompt_includes_limits_and_metadata() -> None:
+    """Ensure extraction prompts expose limit clauses, metadata, and schema text.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Raises:
+        AssertionError: If the prompt omits the limit clause, metadata block, or
+            schema snippet required for downstream validation.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; prompt generation is deterministic.
+    """
+
+    pipeline_input = PipelineInput(
+        content="Important breakthrough details.",
+        source="whitepaper.pdf",
+        metadata={"truncated": True, "files": ["a.py", "b.py"]},
+    )
+    prompts = build_extraction_prompt(
+        pipeline_input,
+        _example_schema(),
+        max_points=5,
+    )
+
+    assert isinstance(prompts, PromptBundle)
+    assert "Return no more than 5 points even if more appear relevant." in prompts.system
+    assert "Return no more than 5 points." in prompts.user
+    assert "Source: whitepaper.pdf" in prompts.user
+    assert "Repository truncation: true" in prompts.user
+    assert "Files aggregated: 2" in prompts.user
+    assert '"title": "ExampleSchema"' in prompts.user
+    assert '"type": "object"' in prompts.user
+
+
+def test_build_query_plan_prompt_formats_points_and_context() -> None:
+    """Verify query plan prompts include formatted points and contextual data.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Raises:
+        AssertionError: If the prompt omits enumerated points, contextual
+            metadata, or the limit instructions required by the checklist.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; prompt generation is deterministic.
+    """
+
+    pipeline_input = PipelineInput(
+        content="Repository summary.",
+        source="repo",
+        metadata={"files": ["README.md"], "truncated": False},
+    )
+    extraction = _example_extraction_result()
+    prompts = build_query_plan_prompt(
+        extraction,
+        _example_schema(),
+        pipeline_input=pipeline_input,
+        max_queries=3,
+    )
+
+    assert isinstance(prompts, PromptBundle)
+    assert "Limit the plan to 3 queries prioritised by impact." in prompts.system
+    assert "Return no more than 3 queries." in prompts.user
+    assert "[1] id=point-1" in prompts.user
+    assert "summary=Critical finding described in detail." in prompts.user
+    assert "Source: repo" in prompts.user
+    assert '"title": "ExampleSchema"' in prompts.user
+    assert '"type": "object"' in prompts.user

--- a/tests/application/preflight/test_services.py
+++ b/tests/application/preflight/test_services.py
@@ -295,3 +295,33 @@ def test_query_service_rejects_non_positive_limits() -> None:
 
     with pytest.raises(ValueError):
         service.run(extraction, max_queries=0)
+
+def test_extraction_service_preserves_truncated_results() -> None:
+    """Confirm truncated results from the gateway propagate without mutation.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Raises:
+        AssertionError: If the service fails to return the truncated artefact as
+            provided by the gateway stub.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable; the stub executes synchronously.
+    """
+
+    pipeline_input = PipelineInput(content="example")
+    result = ExtractionResult(truncated=True)
+    stub = StubPointExtractor(result)
+    service = ExtractionService(gateway=stub)
+
+    returned = service.run(pipeline_input)
+
+    assert returned is result
+    assert returned.truncated is True

--- a/tests/application/preflight/test_services.py
+++ b/tests/application/preflight/test_services.py
@@ -1,0 +1,297 @@
+"""Tests covering the preflight application services.
+
+Purpose:
+    Validate that ``ExtractionService`` and ``QueryBuildingService`` orchestrate
+    gateway interactions by enforcing limit validation, applying defaults, and
+    isolating caller-provided metadata.
+External Dependencies:
+    Relies on ``pytest`` and project-local domain/application modules only.
+Fallback Semantics:
+    Exercises service behaviour without simulating gateway fallbacks; tests focus
+    on ensuring that services propagate gateway results transparently.
+Timeout Strategy:
+    No timeouts are triggered during these tests. Blocking operations are not
+    performed because gateways are replaced with in-memory stubs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Mapping, Optional
+
+import pytest
+
+from src.application.preflight.services import ExtractionService, QueryBuildingService
+from src.domain.preflight import ExtractionResult, QueryPlan
+from src.pipeline_input import PipelineInput
+
+
+@dataclass(slots=True)
+class StubPointExtractor:
+    """Capture invocations made by :class:`ExtractionService` for assertions.
+
+    Attributes:
+        result: Extraction result instance returned for every invocation.
+        calls: Sequence capturing dictionaries of call metadata for assertions.
+    """
+
+    result: ExtractionResult
+    calls: List[Dict[str, object]]
+
+    def __init__(self, result: ExtractionResult) -> None:
+        """Initialise the stub with a precomputed result and empty call log.
+
+        Args:
+            result: Precomputed extraction result returned to the caller.
+
+        Returns:
+            None.
+
+        Raises:
+            None.
+
+        Side Effects:
+            Initialises the ``calls`` list used for assertions.
+
+        Timeout:
+            Not applicable.
+        """
+
+        self.result = result
+        self.calls = []
+
+    def extract_points(
+        self,
+        pipeline_input: PipelineInput,
+        *,
+        max_points: Optional[int] = None,
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> ExtractionResult:
+        """Store call arguments and return the configured result.
+
+        Args:
+            pipeline_input: Pipeline input instance supplied by the service.
+            max_points: Optional limit forwarded from the service under test.
+            metadata: Optional metadata mapping passed by the service.
+
+        Returns:
+            The preconfigured :class:`ExtractionResult` object.
+
+        Raises:
+            None.
+
+        Side Effects:
+            Appends a dictionary describing the invocation to ``calls`` for
+            later inspection.
+
+        Timeout:
+            Not applicable.
+        """
+
+        self.calls.append(
+            {
+                "pipeline_input": pipeline_input,
+                "max_points": max_points,
+                "metadata": metadata,
+            }
+        )
+        return self.result
+
+
+@dataclass(slots=True)
+class StubQueryBuilder:
+    """Capture invocations made by :class:`QueryBuildingService` for assertions.
+
+    Attributes:
+        result: Query plan instance returned to callers for every invocation.
+        calls: Sequence capturing dictionaries of call metadata for assertions.
+    """
+
+    result: QueryPlan
+    calls: List[Dict[str, object]]
+
+    def __init__(self, result: QueryPlan) -> None:
+        """Initialise the stub with a precomputed result and empty call log.
+
+        Args:
+            result: Precomputed query plan returned to callers.
+
+        Returns:
+            None.
+
+        Raises:
+            None.
+
+        Side Effects:
+            Initialises the ``calls`` list used to assert invocation data.
+
+        Timeout:
+            Not applicable.
+        """
+
+        self.result = result
+        self.calls = []
+
+    def build_queries(
+        self,
+        extraction: ExtractionResult,
+        pipeline_input: Optional[PipelineInput] = None,
+        *,
+        max_queries: Optional[int] = None,
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> QueryPlan:
+        """Store call arguments and return the configured result.
+
+        Args:
+            extraction: Extraction result forwarded by the service under test.
+            pipeline_input: Optional pipeline input forwarded by the service.
+            max_queries: Optional limit forwarded by the service.
+            metadata: Optional metadata mapping provided by the service.
+
+        Returns:
+            The preconfigured :class:`QueryPlan` object.
+
+        Raises:
+            None.
+
+        Side Effects:
+            Appends a dictionary describing the invocation to ``calls`` for
+            later inspection.
+
+        Timeout:
+            Not applicable.
+        """
+
+        self.calls.append(
+            {
+                "extraction": extraction,
+                "pipeline_input": pipeline_input,
+                "max_queries": max_queries,
+                "metadata": metadata,
+            }
+        )
+        return self.result
+
+
+def test_extraction_service_uses_override_and_copies_metadata() -> None:
+    """Ensure overrides take precedence and metadata is defensively copied.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Raises:
+        AssertionError: If the override limit or metadata copy behaviour is
+            incorrect.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable.
+    """
+
+    pipeline_input = PipelineInput(content="example")
+    metadata: Dict[str, object] = {"run": "abc"}
+    result = ExtractionResult()
+    stub = StubPointExtractor(result)
+    service = ExtractionService(gateway=stub, default_max_points=3)
+
+    returned = service.run(pipeline_input, max_points=5, metadata=metadata)
+
+    assert returned is result
+    assert stub.calls[0]["pipeline_input"] is pipeline_input
+    assert stub.calls[0]["max_points"] == 5
+    assert stub.calls[0]["metadata"] == {"run": "abc"}
+    assert stub.calls[0]["metadata"] is not metadata
+    metadata["run"] = "changed"
+    assert stub.calls[0]["metadata"] == {"run": "abc"}
+
+
+def test_extraction_service_rejects_non_positive_limits() -> None:
+    """Verify that invalid limits raise ``ValueError``.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Raises:
+        AssertionError: If ``ValueError`` is not raised as expected.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable.
+    """
+
+    pipeline_input = PipelineInput(content="example")
+    stub = StubPointExtractor(ExtractionResult())
+    service = ExtractionService(gateway=stub)
+
+    with pytest.raises(ValueError):
+        service.run(pipeline_input, max_points=0)
+
+
+def test_query_service_applies_default_limit_when_override_missing() -> None:
+    """Ensure default limits are used when explicit overrides are absent.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Raises:
+        AssertionError: If the default limit is not forwarded to the gateway.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable.
+    """
+
+    extraction = ExtractionResult()
+    query_plan = QueryPlan()
+    stub = StubQueryBuilder(query_plan)
+    service = QueryBuildingService(gateway=stub, default_max_queries=7)
+
+    returned = service.run(extraction)
+
+    assert returned is query_plan
+    assert stub.calls[0]["extraction"] is extraction
+    assert stub.calls[0]["pipeline_input"] is None
+    assert stub.calls[0]["max_queries"] == 7
+    assert stub.calls[0]["metadata"] is None
+
+
+def test_query_service_rejects_non_positive_limits() -> None:
+    """Verify that invalid query limits raise ``ValueError``.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Raises:
+        AssertionError: If ``ValueError`` is not raised as expected.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable.
+    """
+
+    extraction = ExtractionResult()
+    stub = StubQueryBuilder(QueryPlan())
+    service = QueryBuildingService(gateway=stub)
+
+    with pytest.raises(ValueError):
+        service.run(extraction, max_queries=0)

--- a/tests/infrastructure/preflight/test_openai_gateway.py
+++ b/tests/infrastructure/preflight/test_openai_gateway.py
@@ -1,0 +1,290 @@
+"""Unit tests for the OpenAI-backed preflight gateways."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+from src.domain.preflight import ExtractedPoint, ExtractionResult
+from src.infrastructure.preflight.openai_gateway import (
+    OpenAIPointExtractorGateway,
+    OpenAIQueryBuilderGateway,
+)
+from src.pipeline_input import PipelineInput
+
+
+class DummyCall:
+    """Test double that simulates the OpenAI client."""
+
+    def __init__(self, responses: Iterable[Any]) -> None:
+        self._responses = iter(responses)
+        self.calls: List[Dict[str, Any]] = []
+
+    def __call__(
+        self,
+        *,
+        prompt_template: str,
+        context: Mapping[str, Any],
+        config: Mapping[str, Any],
+        is_structured: bool,
+        system_message: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Tuple[Any, str]:
+        """Return the next prepared response while recording invocation metadata.
+
+        Args:
+            prompt_template: User prompt supplied to the provider.
+            context: Prompt rendering context (unused but recorded for tests).
+            config: Provider configuration mapping forwarded by the gateway.
+            is_structured: Flag indicating whether structured output is
+                expected.
+            system_message: Optional system prompt supplied by the gateway.
+            **kwargs: Additional provider overrides such as ``max_tokens``.
+
+        Returns:
+            Tuple containing the prepared payload and a fixed model name.
+
+        Raises:
+            AssertionError: If the call is invoked more times than prepared
+                responses.
+
+        Side Effects:
+            Appends metadata to ``self.calls`` for later inspection.
+
+        Timeout:
+            Not applicable.
+        """
+
+        self.calls.append(
+            {
+                "prompt": prompt_template,
+                "context": dict(context),
+                "config": dict(config),
+                "is_structured": is_structured,
+                "system": system_message,
+                "overrides": dict(kwargs),
+            }
+        )
+        try:
+            payload = next(self._responses)
+        except StopIteration:  # pragma: no cover - defensive
+            raise AssertionError("DummyCall invoked more times than expected")
+        return payload, "gpt-5"
+
+
+def _make_valid_extraction_payload() -> Dict[str, Any]:
+    """Return a payload that satisfies the extraction schema."""
+
+    return {
+        "points": [
+            {
+                "id": "p-1",
+                "title": "Discovery",
+                "summary": "Key finding summarised for downstream steps.",
+                "evidence_refs": ["paper.md#L10"],
+                "confidence": 0.9,
+                "tags": ["physics"],
+            }
+        ],
+        "source_stats": {"characters": 42},
+        "truncated": False,
+    }
+
+
+def _make_valid_query_payload() -> Dict[str, Any]:
+    """Return a payload that satisfies the query plan schema."""
+
+    return {
+        "queries": [
+            {
+                "id": "q-1",
+                "text": "What experimental setups support the claim?",
+                "purpose": "Validate experimental backing.",
+                "priority": 1,
+                "depends_on_ids": [],
+                "target_audience": "reviewer",
+                "suggested_tooling": ["web_search"],
+            }
+        ],
+        "rationale": "Focus on reproducibility first.",
+        "assumptions": [],
+        "risks": ["Limited experimental details provided."],
+    }
+
+
+def test_point_extractor_success_single_attempt() -> None:
+    """Verify success when the initial extraction attempt is valid.
+
+    Returns:
+        None.
+
+    Raises:
+        AssertionError: If the gateway does not return the expected point.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable.
+    """
+
+    call = DummyCall([_make_valid_extraction_payload()])
+    gateway = OpenAIPointExtractorGateway(call_model=call, config={})
+    pipeline_input = PipelineInput(content="Example content", source="unit-test")
+
+    result = gateway.extract_points(pipeline_input)
+
+    assert len(call.calls) == 1
+    assert result.points[0].id == "p-1"
+    assert result.validation_errors == ()
+
+
+def test_point_extractor_retries_on_validation_error() -> None:
+    """Ensure a retry occurs when the first response fails validation.
+
+    Returns:
+        None.
+
+    Raises:
+        AssertionError: If the retry does not occur or the result is invalid.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable.
+    """
+
+    invalid = "{invalid json"
+    call = DummyCall([invalid, _make_valid_extraction_payload()])
+    gateway = OpenAIPointExtractorGateway(call_model=call, config={}, max_retries=1)
+    pipeline_input = PipelineInput(content="Example content", source="unit-test")
+
+    result = gateway.extract_points(pipeline_input)
+
+    assert len(call.calls) == 2
+    assert result.points[0].id == "p-1"
+    assert result.validation_errors == ()
+
+
+def test_point_extractor_returns_fallback_after_retry_failure() -> None:
+    """Confirm the fallback artefact is returned when retries fail.
+
+    Returns:
+        None.
+
+    Raises:
+        AssertionError: If fallback metadata is not exposed as expected.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable.
+    """
+
+    invalid_first = "not json"
+    invalid_second = json.dumps({"points": []})
+    call = DummyCall([invalid_first, invalid_second])
+    gateway = OpenAIPointExtractorGateway(call_model=call, config={}, max_retries=1)
+    pipeline_input = PipelineInput(content="Example content", source="unit-test")
+
+    result = gateway.extract_points(pipeline_input)
+
+    assert len(call.calls) == 2
+    assert result.points == ()
+    assert result.raw_response == invalid_second
+    assert result.validation_errors
+
+
+def test_point_extractor_honours_metadata_overrides() -> None:
+    """Validate that metadata can override provider token limits.
+
+    Returns:
+        None.
+
+    Raises:
+        AssertionError: If the override is not forwarded to the provider call.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable.
+    """
+
+    call = DummyCall([_make_valid_extraction_payload()])
+    gateway = OpenAIPointExtractorGateway(call_model=call, config={}, max_retries=0)
+    pipeline_input = PipelineInput(content="Example content", source="unit-test")
+
+    gateway.extract_points(
+        pipeline_input,
+        metadata={"max_output_tokens": 1234},
+    )
+
+    assert call.calls[0]["overrides"]["max_tokens"] == 1234
+
+
+def test_query_builder_successful_execution() -> None:
+    """Verify successful query plan parsing without retries.
+
+    Returns:
+        None.
+
+    Raises:
+        AssertionError: If the parsed plan does not match expectations.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable.
+    """
+
+    call = DummyCall([_make_valid_query_payload()])
+    gateway = OpenAIQueryBuilderGateway(call_model=call, config={})
+    extraction = ExtractionResult(
+        points=(
+            ExtractedPoint(
+                id="p-1",
+                title="Discovery",
+                summary="Key finding",
+                evidence_refs=("paper.md#L10",),
+                confidence=0.9,
+            ),
+        )
+    )
+
+    plan = gateway.build_queries(extraction)
+
+    assert len(call.calls) == 1
+    assert plan.queries[0].id == "q-1"
+    assert plan.validation_errors == ()
+
+
+def test_query_builder_retries_before_fallback() -> None:
+    """Ensure query builder retries and returns fallback when still invalid.
+
+    Returns:
+        None.
+
+    Raises:
+        AssertionError: If retries or fallback behaviour are incorrect.
+
+    Side Effects:
+        None.
+
+    Timeout:
+        Not applicable.
+    """
+
+    call = DummyCall(["not json", "{}"])  # Second payload lacks required fields
+    gateway = OpenAIQueryBuilderGateway(call_model=call, config={}, max_retries=1)
+    extraction = ExtractionResult(points=())
+
+    plan = gateway.build_queries(extraction)
+
+    assert len(call.calls) == 2
+    assert plan.queries == ()
+    assert plan.raw_response == "{}"
+    assert plan.validation_errors

--- a/tests/integration/test_cli_preflight_artifacts.py
+++ b/tests/integration/test_cli_preflight_artifacts.py
@@ -1,0 +1,318 @@
+"""Integration tests verifying CLI preflight artefact persistence.
+
+Purpose:
+    Ensure the console application writes structured extraction and query plan
+    artefacts when the corresponding preflight flags are enabled. The tests use
+    real CLI wiring with stubbed gateways to validate schema compliance without
+    invoking external providers.
+External Dependencies:
+    Relies on :mod:`pytest` and Python's standard library (``pathlib`` and
+    ``types``). All application imports originate from the repository under
+    test.
+Fallback Semantics:
+    Gateway and orchestrator stubs provide deterministic responses so the CLI
+    behaviour can be exercised without retries or network fallbacks.
+Timeout Strategy:
+    Not applicable. The tests perform synchronous filesystem operations within
+    pytest-managed temporary directories.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import List, Optional, Tuple
+
+import pytest
+
+from src.application.critique.services import CritiqueRunner
+from src.application.preflight.extraction_parser import ExtractionResponseParser
+from src.application.preflight.orchestrator import PreflightOptions, PreflightRunResult
+from src.application.preflight.query_parser import QueryPlanResponseParser
+from src.domain.preflight import BuiltQuery, ExtractionResult, ExtractedPoint, QueryPlan
+from src.domain.user_settings.models import UserSettings
+from src.infrastructure.io.file_repository import FileSystemContentRepositoryFactory
+from src.pipeline_input import PipelineInput
+from src.presentation.cli.app import CliApp
+from src.presentation.cli.preflight import PreflightCliDefaults
+
+pytestmark = pytest.mark.integration
+
+
+class _StubSettingsService:
+    """In-memory settings service tailored for CLI integration scenarios."""
+
+    def __init__(self) -> None:
+        self._settings = UserSettings()
+        self.recorded: List[str] = []
+        self.saved_outputs: List[Optional[str]] = []
+
+    def get_settings(self) -> UserSettings:
+        """Return mutable user settings consumed by the CLI and runner."""
+
+        return self._settings
+
+    def record_recent_file(self, path: str) -> None:
+        """Track recently accessed pipeline sources for assertions."""
+
+        self.recorded.append(path)
+
+    def set_default_output_dir(self, value: Optional[str]) -> None:
+        """Store output directory preferences when the CLI requests persistence."""
+
+        self.saved_outputs.append(value)
+        self._settings.default_output_dir = value or None
+
+
+class _StaticConfigBuilder:
+    """Configuration builder that returns a static payload for tests."""
+
+    def __init__(self, payload: Optional[dict[str, object]] = None) -> None:
+        self._payload = payload or {"api": {"providers": {}}}
+
+    def build(self) -> dict[str, object]:
+        """Return a shallow copy of the configured payload."""
+
+        return dict(self._payload)
+
+
+class _StaticCritiqueGateway:
+    """Gateway stub that records invocations and returns canned output."""
+
+    def __init__(self) -> None:
+        self.invocations: List[PipelineInput] = []
+
+    def run(
+        self,
+        pipeline_input: PipelineInput,
+        config: dict[str, object],
+        peer_review: bool,
+        scientific_mode: bool,
+    ) -> str:
+        """Record parameters and return a deterministic critique string."""
+
+        self.invocations.append(pipeline_input)
+        return "Rendered critique"
+
+
+class _StubPreflightOrchestrator:
+    """Deterministic orchestrator stub that emits predefined results."""
+
+    def __init__(
+        self,
+        *,
+        extraction: ExtractionResult | None = None,
+        query_plan: QueryPlan | None = None,
+    ) -> None:
+        self._extraction = extraction
+        self._query_plan = query_plan
+        self.invocations: List[Tuple[PipelineInput, PreflightOptions]] = []
+
+    def run(self, pipeline_input: PipelineInput, options: PreflightOptions) -> PreflightRunResult:
+        """Return preconfigured artefacts while recording invocation metadata."""
+
+        self.invocations.append((pipeline_input, options))
+        artifact_paths: dict[str, str] = {}
+        extraction = self._extraction if options.enable_extraction else None
+        if extraction is not None and options.extraction_artifact_name:
+            artifact_paths["extraction"] = options.extraction_artifact_name
+        plan = self._query_plan if options.enable_query_building else None
+        if plan is not None and options.query_artifact_name:
+            artifact_paths["query_plan"] = options.query_artifact_name
+        return PreflightRunResult(
+            extraction=extraction,
+            query_plan=plan,
+            artifact_paths=artifact_paths,
+        )
+
+
+def _make_extraction_result() -> ExtractionResult:
+    """Create a representative extraction result for CLI persistence tests."""
+
+    point = ExtractedPoint(
+        id="pt-001",
+        title="Key observation",
+        summary="Summarise the most critical insight discovered during review.",
+        evidence_refs=("notes.md#L10",),
+        confidence=0.9,
+        tags=("research", "priority"),
+    )
+    return ExtractionResult(
+        points=(point,),
+        source_stats={"token_usage": 512},
+        truncated=False,
+    )
+
+
+def _make_query_plan() -> QueryPlan:
+    """Create a deterministic query plan payload for integration testing."""
+
+    query = BuiltQuery(
+        id="q-001",
+        text="How will we extend coverage to related work?",
+        purpose="Clarify the roadmap for subsequent critique stages.",
+        priority=1,
+        depends_on_ids=("pt-001",),
+        target_audience="author",
+        suggested_tooling=("search",),
+    )
+    return QueryPlan(
+        queries=(query,),
+        rationale="Ensure upcoming analysis addresses outstanding questions.",
+        assumptions=("Up-to-date bibliography",),
+        risks=("Scope creep",),
+    )
+
+
+def _build_cli_args(
+    input_source: PipelineInput,
+    output_dir: Path,
+    *,
+    enable_extraction: bool,
+    enable_query_building: bool,
+    points_path: Optional[str] = None,
+    queries_path: Optional[str] = None,
+    max_points: Optional[int] = None,
+    max_queries: Optional[int] = None,
+) -> SimpleNamespace:
+    """Construct a CLI namespace mirroring parsed arguments for tests."""
+
+    return SimpleNamespace(
+        input_file=input_source,
+        input_dir=None,
+        include=None,
+        exclude=None,
+        order=None,
+        order_from=None,
+        recursive=None,
+        label_sections=None,
+        max_files=None,
+        max_chars=None,
+        section_separator=None,
+        output_dir=str(output_dir),
+        peer_review=None,
+        scientific_mode=None,
+        latex=False,
+        latex_compile=False,
+        latex_output_dir=None,
+        latex_scientific_level="high",
+        direct_latex=False,
+        remember_output=False,
+        preflight_extract=enable_extraction,
+        preflight_build_queries=enable_query_building,
+        points_out=points_path,
+        queries_out=queries_path,
+        max_points=max_points,
+        max_queries=max_queries,
+        interactive_mode=None,
+    )
+
+
+def test_cli_preflight_extract_writes_schema_compliant_points(tmp_path: Path) -> None:
+    """Verify ``--preflight-extract`` persists JSON matching the extraction schema."""
+
+    settings_service = _StubSettingsService()
+    repository_factory = FileSystemContentRepositoryFactory()
+    orchestrator = _StubPreflightOrchestrator(extraction=_make_extraction_result())
+    gateway = _StaticCritiqueGateway()
+    runner = CritiqueRunner(
+        settings_service,
+        _StaticConfigBuilder(),
+        gateway,
+        repository_factory,
+        preflight_orchestrator=orchestrator,
+    )
+    defaults = PreflightCliDefaults(
+        extract_enabled=False,
+        query_enabled=False,
+        points_artifact="points.json",
+        queries_artifact="queries.json",
+    )
+    app = CliApp(
+        settings_service,
+        runner,
+        preflight_defaults=defaults,
+        output_func=lambda _: None,
+    )
+    pipeline_input = PipelineInput(content="Body", metadata={"source_path": "notes.md"})
+    args = _build_cli_args(
+        pipeline_input,
+        tmp_path,
+        enable_extraction=True,
+        enable_query_building=False,
+    )
+
+    app.run(args, interactive=False)
+
+    points_path = tmp_path / "points.json"
+    assert points_path.exists(), "expected extraction artefact to be written"
+    payload = points_path.read_text(encoding="utf-8")
+    parser = ExtractionResponseParser()
+    result = parser.parse(payload)
+    assert not result.validation_errors
+    assert result.model is not None
+    assert result.model.points and result.model.points[0].title == "Key observation"
+    assert orchestrator.invocations, "preflight orchestrator should be invoked"
+    _invocation_input, options = orchestrator.invocations[0]
+    assert options.enable_extraction is True
+    assert options.enable_query_building is False
+    assert "preflight_artifacts" in pipeline_input.metadata
+    assert pipeline_input.metadata["preflight_artifacts"]["extraction"] == str(points_path)
+
+
+def test_cli_preflight_query_writes_schema_compliant_plan(tmp_path: Path) -> None:
+    """Verify ``--preflight-build-queries`` emits a query plan artefact."""
+
+    settings_service = _StubSettingsService()
+    repository_factory = FileSystemContentRepositoryFactory()
+    orchestrator = _StubPreflightOrchestrator(
+        extraction=_make_extraction_result(),
+        query_plan=_make_query_plan(),
+    )
+    gateway = _StaticCritiqueGateway()
+    runner = CritiqueRunner(
+        settings_service,
+        _StaticConfigBuilder(),
+        gateway,
+        repository_factory,
+        preflight_orchestrator=orchestrator,
+    )
+    defaults = PreflightCliDefaults(
+        extract_enabled=False,
+        query_enabled=False,
+        points_artifact="points.json",
+        queries_artifact="queries.json",
+    )
+    app = CliApp(
+        settings_service,
+        runner,
+        preflight_defaults=defaults,
+        output_func=lambda _: None,
+    )
+    pipeline_input = PipelineInput(content="Body", metadata={"source_path": "notes.md"})
+    args = _build_cli_args(
+        pipeline_input,
+        tmp_path,
+        enable_extraction=True,
+        enable_query_building=True,
+        queries_path="custom_queries.json",
+    )
+
+    app.run(args, interactive=False)
+
+    points_path = tmp_path / "points.json"
+    assert points_path.exists(), "extraction artefact should accompany query planning"
+    queries_path = tmp_path / "custom_queries.json"
+    assert queries_path.exists(), "expected query plan artefact to be written"
+    parser = QueryPlanResponseParser()
+    plan_result = parser.parse(queries_path.read_text(encoding="utf-8"))
+    assert not plan_result.validation_errors
+    assert plan_result.model is not None
+    assert plan_result.model.queries and plan_result.model.queries[0].text.startswith("How will we extend")
+    assert orchestrator.invocations, "preflight orchestrator should record invocations"
+    _invocation_input, options = orchestrator.invocations[0]
+    assert options.enable_extraction is True
+    assert options.enable_query_building is True
+    metadata = pipeline_input.metadata.get("preflight_artifacts", {})
+    assert metadata["extraction"] == str(points_path)
+    assert metadata["query_plan"] == str(queries_path)

--- a/tests/presentation/cli/helpers.py
+++ b/tests/presentation/cli/helpers.py
@@ -7,6 +7,7 @@ from typing import Callable, Dict, Iterable, List, Tuple
 from unittest.mock import MagicMock
 
 from src.presentation.cli.app import CliApp, DirectoryInputDefaults
+from src.presentation.cli.preflight import PreflightCliDefaults
 
 
 class FakeSettings:
@@ -110,6 +111,7 @@ def make_app(
     settings_service: FakeSettingsService | None = None,
     critique_runner: MagicMock | None = None,
     directory_defaults: DirectoryInputDefaults | None = None,
+    preflight_defaults: PreflightCliDefaults | None = None,
 ) -> Tuple[CliApp, List[str], FakeSettingsService, MagicMock, List[str]]:
     """Create a :class:`CliApp` wired with fake dependencies for testing."""
 
@@ -122,6 +124,7 @@ def make_app(
         service,
         runner,
         directory_defaults=directory_defaults,
+        preflight_defaults=preflight_defaults,
         input_func=input_func,
         output_func=messages.append,
     )

--- a/tests/presentation/cli/test_app_interactive.py
+++ b/tests/presentation/cli/test_app_interactive.py
@@ -19,10 +19,10 @@ def test_run_interactive_routes_to_handlers(monkeypatch: pytest.MonkeyPatch) -> 
     inputs = ["1", "2", "3", "4", "q"]
     app, messages, _service, _runner, _prompts = make_app(input_values=inputs)
     called: List[str] = []
-    monkeypatch.setattr(app, "_interactive_run_flow", lambda: called.append("run"))
-    monkeypatch.setattr(app, "_preferences_menu", lambda: called.append("prefs"))
-    monkeypatch.setattr(app, "_api_keys_menu", lambda: called.append("keys"))
-    monkeypatch.setattr(app, "_display_settings", lambda: called.append("display"))
+    monkeypatch.setattr(app._interactive, "_interactive_run_flow", lambda: called.append("run"))
+    monkeypatch.setattr(app._interactive, "_preferences_menu", lambda: called.append("prefs"))
+    monkeypatch.setattr(app._interactive, "_api_keys_menu", lambda: called.append("keys"))
+    monkeypatch.setattr(app._interactive, "_display_settings", lambda: called.append("display"))
 
     app._run_interactive()
 
@@ -35,15 +35,15 @@ def test_interactive_run_flow_uses_prompts(monkeypatch: pytest.MonkeyPatch, tmp_
     app = CliApp(service, MagicMock(), input_func=lambda _: "", output_func=lambda _: None)
 
     input_path = tmp_path / "input.md"
-    monkeypatch.setattr(app, "_prompt_for_input_path", lambda _settings: input_path)
-    monkeypatch.setattr(app, "_prompt_for_output_directory", lambda _settings: tmp_path)
-    monkeypatch.setattr(app, "_prompt_bool", lambda message, default: True)
+    monkeypatch.setattr(app._interactive, "_prompt_for_input_path", lambda _settings: input_path)
+    monkeypatch.setattr(app._interactive, "_prompt_for_output_directory", lambda _settings: tmp_path)
+    monkeypatch.setattr(app._interactive, "_prompt_bool", lambda message, default: True)
     latex_args = SimpleNamespace(latex=True)
-    monkeypatch.setattr(app, "_prompt_latex_options", lambda _output_dir: latex_args)
+    monkeypatch.setattr(app._interactive, "_prompt_latex_options", lambda _output_dir: latex_args)
     calls: List[tuple[tuple[object, ...], dict[str, object]]] = []
     monkeypatch.setattr(
-        app,
-        "_execute_run",
+        app._interactive,
+        "execute_run",
         lambda *args, **kwargs: calls.append((args, kwargs)),
     )
 

--- a/tests/presentation/cli/test_preflight_configuration.py
+++ b/tests/presentation/cli/test_preflight_configuration.py
@@ -1,0 +1,116 @@
+"""Tests for CLI preflight configuration helpers and config resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Mapping
+
+from run_critique import determine_config_path
+from src.presentation.cli.preflight import PreflightCliDefaults, load_preflight_defaults
+from tests.presentation.cli.helpers import FakeSettings, FakeSettingsService
+
+
+def _build_config(
+    *,
+    extract_enabled: bool = False,
+    query_enabled: bool = False,
+    max_points: int | None = None,
+    max_queries: int | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> Mapping[str, Any]:
+    """Return a representative configuration mapping for tests."""
+
+    return {
+        "preflight": {
+            "provider": "openai",
+            "metadata": dict(metadata or {}),
+            "extract": {
+                "enabled": extract_enabled,
+                "max_points": max_points,
+                "artifact_path": "artifacts/points.json",
+            },
+            "queries": {
+                "enabled": query_enabled,
+                "max_queries": max_queries,
+                "artifact_path": "artifacts/queries.json",
+            },
+        }
+    }
+
+
+def test_load_preflight_defaults_reads_configuration() -> None:
+    """Ensure `load_preflight_defaults` reflects the JSON configuration."""
+
+    config = _build_config(
+        extract_enabled=True,
+        query_enabled=True,
+        max_points=7,
+        max_queries=5,
+        metadata={"stage": "preflight"},
+    )
+
+    defaults = load_preflight_defaults(config)
+
+    assert isinstance(defaults, PreflightCliDefaults)
+    assert defaults.provider == "openai"
+    assert defaults.extract_enabled is True
+    assert defaults.query_enabled is True
+    assert defaults.max_points == 7
+    assert defaults.max_queries == 5
+    assert defaults.points_artifact == "artifacts/points.json"
+    assert defaults.queries_artifact == "artifacts/queries.json"
+    assert defaults.metadata == {"stage": "preflight"}
+
+
+def test_load_preflight_defaults_handles_missing_sections() -> None:
+    """Verify defaults remain safe when configuration entries are absent."""
+
+    defaults = load_preflight_defaults({})
+
+    assert defaults.extract_enabled is False
+    assert defaults.query_enabled is False
+    assert defaults.max_points is None
+    assert defaults.max_queries is None
+    assert defaults.points_artifact == "artifacts/points.json"
+    assert defaults.queries_artifact == "artifacts/queries.json"
+    assert defaults.metadata == {}
+
+
+def test_determine_config_path_accepts_json_override(tmp_path: Path) -> None:
+    """Ensure CLI override returning a JSON file is honoured as-is."""
+
+    config_path = tmp_path / "custom.json"
+    config_path.write_text("{}", encoding="utf-8")
+    args = SimpleNamespace(config=str(config_path))
+    service = FakeSettingsService()
+
+    resolved = determine_config_path(args, service)
+
+    assert resolved == config_path
+
+
+def test_determine_config_path_rejects_yaml_paths() -> None:
+    """Verify YAML configuration entries fall back to ``config.json``."""
+
+    service = FakeSettingsService(FakeSettings())
+    service.get_settings().config_path = "settings.yaml"
+    args = SimpleNamespace(config=None)
+
+    resolved = determine_config_path(args, service)
+
+    assert resolved == Path("config.json")
+
+
+def test_determine_config_path_prefers_cli_override_over_settings(tmp_path: Path) -> None:
+    """Confirm CLI overrides supersede stored settings with JSON paths."""
+
+    config_path = tmp_path / "run.json"
+    config_path.write_text("{}", encoding="utf-8")
+    service = FakeSettingsService(FakeSettings())
+    service.get_settings().config_path = str(tmp_path / "old.json")
+    args = SimpleNamespace(config=str(config_path))
+
+    resolved = determine_config_path(args, service)
+
+    assert resolved == config_path

--- a/tests/test_reasoning_tree.py
+++ b/tests/test_reasoning_tree.py
@@ -4,7 +4,7 @@
 
 import os
 import sys
-from typing import Dict
+from typing import Any, Dict, List, Optional
 from unittest.mock import patch
 
 import pytest
@@ -21,7 +21,7 @@ STYLE_DIRECTIVES = "Unit test style directives"
 def stub_call_with_retry(monkeypatch):
     """Provide deterministic responses for the provider interactions."""
 
-    def _fake_call(prompt_template, context, config, is_structured=False):
+    def _fake_call(prompt_template, context, config, is_structured=False, structured_output_schema=None):
         if "Based on the primary critique claim" in prompt_template:
             return ({"topics": ["Topic A", "Topic B"]}, "stub-model")
         return (
@@ -145,7 +145,7 @@ def test_tree_distributes_assigned_points(base_config, monkeypatch):
 
     assessment_contexts = []
 
-    def _call_with_retry(prompt_template, context, config, is_structured=False):
+    def _call_with_retry(prompt_template, context, config, is_structured=False, structured_output_schema=None):
         if 'Based on the primary critique claim' in prompt_template:
             _call_with_retry.decomposition_calls += 1
             if _call_with_retry.decomposition_calls == 1:
@@ -197,7 +197,7 @@ def test_tree_distributes_assigned_points(base_config, monkeypatch):
 def test_tree_handles_assessment_provider_error(base_config, monkeypatch):
     """Provider-layer failures should yield a pruned branch."""
 
-    def _failing_call(prompt_template, context, config, is_structured=False):
+    def _failing_call(prompt_template, context, config, is_structured=False, structured_output_schema=None):
         raise JsonParsingError('bad json payload')
 
     monkeypatch.setattr('src.reasoning_tree.call_with_retry', _failing_call)
@@ -210,7 +210,7 @@ def test_tree_handles_assessment_provider_error(base_config, monkeypatch):
 def test_tree_handles_unexpected_assessment_error(base_config, monkeypatch):
     """Unexpected provider errors should also prune the branch."""
 
-    def _unexpected_call(prompt_template, context, config, is_structured=False):
+    def _unexpected_call(prompt_template, context, config, is_structured=False, structured_output_schema=None):
         if 'Based on the primary critique claim' in prompt_template:
             return [], 'stub-model'
         raise RuntimeError('unexpected failure')
@@ -225,7 +225,7 @@ def test_tree_handles_unexpected_assessment_error(base_config, monkeypatch):
 def test_tree_handles_decomposition_provider_error(base_config, monkeypatch):
     """Failures during decomposition should be logged and still return a node."""
 
-    def _call_with_retry(prompt_template, context, config, is_structured=False):
+    def _call_with_retry(prompt_template, context, config, is_structured=False, structured_output_schema=None):
         if 'Based on the primary critique claim' in prompt_template:
             raise JsonProcessingError('bad decomposition payload')
         return (
@@ -251,7 +251,7 @@ def test_tree_handles_decomposition_provider_error(base_config, monkeypatch):
 def test_tree_handles_unexpected_decomposition_error(base_config, monkeypatch, caplog):
     """Unexpected decomposition exceptions should be logged and allow execution to continue."""
 
-    def _call_with_retry(prompt_template, context, config, is_structured=False):
+    def _call_with_retry(prompt_template, context, config, is_structured=False, structured_output_schema=None):
         if 'Based on the primary critique claim' in prompt_template:
             raise RuntimeError('decomposition failed')
         return (
@@ -279,7 +279,7 @@ def test_tree_handles_unexpected_decomposition_error(base_config, monkeypatch, c
 def test_tree_accepts_list_based_decomposition(base_config, monkeypatch, caplog):
     """Lists of strings from the decomposition provider should remain supported."""
 
-    def _call_with_retry(prompt_template, context, config, is_structured=False):
+    def _call_with_retry(prompt_template, context, config, is_structured=False, structured_output_schema=None):
         if 'Based on the primary critique claim' in prompt_template:
             return (["Topic 1", "Topic 2"], 'stub-model')
         return (
@@ -306,7 +306,7 @@ def test_tree_accepts_list_based_decomposition(base_config, monkeypatch, caplog)
 def test_tree_accepts_alternative_topic_keys(base_config, monkeypatch, caplog):
     """Mappings with "items" or "subtopics" keys should normalise correctly."""
 
-    def _call_with_retry(prompt_template, context, config, is_structured=False):
+    def _call_with_retry(prompt_template, context, config, is_structured=False, structured_output_schema=None):
         if 'Based on the primary critique claim' in prompt_template:
             return ({'items': ['Topic 1']}, 'stub-model')
         return (
@@ -333,7 +333,7 @@ def test_tree_accepts_alternative_topic_keys(base_config, monkeypatch, caplog):
 def test_tree_warns_on_invalid_decomposition_structure(base_config, caplog, monkeypatch):
     """Unexpected decomposition results should trigger a warning."""
 
-    def _call_with_retry(prompt_template, context, config, is_structured=False):
+    def _call_with_retry(prompt_template, context, config, is_structured=False, structured_output_schema=None):
         if 'Based on the primary critique claim' in prompt_template:
             return {'invalid': 'structure'}, 'stub-model'
         return (
@@ -358,6 +358,93 @@ def test_tree_warns_on_invalid_decomposition_structure(base_config, caplog, monk
     assert len(warnings) == 1
     assert 'provider=' in warnings[0]
     assert 'keys=invalid' in warnings[0]
+
+
+def test_o_series_requests_json_schema(base_config, monkeypatch):
+    """o-series models should request a JSON schema for decomposition topics."""
+
+    captured_schema: Dict[str, Any] = {}
+
+    def _call_with_retry(prompt_template, context, config, is_structured=False, structured_output_schema=None):
+        if 'Based on the primary critique claim' in prompt_template:
+            captured_schema['value'] = structured_output_schema
+            return (['Topic 1'], 'o1-mini')
+        return (
+            {
+                'claim': 'Primary finding',
+                'evidence': 'Detailed evidence',
+                'confidence': 0.9,
+                'severity': 'high',
+                'recommendation': 'Action',
+                'concession': 'None',
+            },
+            'assessment-model',
+        )
+
+    config = {
+        **base_config,
+        'api': {
+            'primary_provider': 'openai',
+            'openai': {'model': 'o1-mini'},
+        },
+    }
+
+    monkeypatch.setattr('src.reasoning_tree.call_with_retry', _call_with_retry)
+
+    result = execute_reasoning_tree('Extensive content segment.' * 5, STYLE_DIRECTIVES, 'TestAgent', config)
+
+    assert result is not None
+    assert 'value' in captured_schema
+    schema = captured_schema['value']
+    assert schema is not None
+    assert schema.get('schema', {}).get('type') == 'array'
+    assert schema.get('schema', {}).get('items', {}).get('type') == 'string'
+
+
+def test_decomposition_recurses_without_repeated_warnings(base_config, monkeypatch, caplog):
+    """gpt-5 executions should recurse cleanly without duplicate warnings."""
+
+    config = {
+        **base_config,
+        'api': {
+            'primary_provider': 'openai',
+            'openai': {'model': 'gpt-5'},
+        },
+    }
+
+    decomposition_calls = 0
+    observed_schemas: List[Optional[Dict[str, Any]]] = []
+
+    def _call_with_retry(prompt_template, context, config, is_structured=False, structured_output_schema=None):
+        nonlocal decomposition_calls
+        if 'Based on the primary critique claim' in prompt_template:
+            decomposition_calls += 1
+            observed_schemas.append(structured_output_schema)
+            if decomposition_calls == 1:
+                return ({'topics': ['Topic 1', 'Topic 2']}, 'gpt-5')
+            return ({'topics': []}, 'gpt-5')
+        return (
+            {
+                'claim': 'Primary finding',
+                'evidence': 'Detailed evidence',
+                'confidence': 0.9,
+                'severity': 'high',
+                'recommendation': 'Action',
+                'concession': 'None',
+            },
+            'assessment-model',
+        )
+
+    monkeypatch.setattr('src.reasoning_tree.call_with_retry', _call_with_retry)
+
+    with caplog.at_level('INFO', logger='src.reasoning_tree'):
+        result = execute_reasoning_tree('Extensive content segment.' * 5, STYLE_DIRECTIVES, 'TestAgent', config)
+
+    assert result is not None
+    assert len(result['sub_critiques']) == 2
+    assert all(schema is None for schema in observed_schemas)
+    warnings = [message for message in caplog.messages if 'Unexpected decomposition structure' in message]
+    assert len(warnings) <= 1
 
 
 def test_run_example_executes_without_error(caplog):


### PR DESCRIPTION
## Summary
- add infrastructure OpenAI gateways that enforce schema-aware retries, metadata overrides, and timeout controls when invoking providers
- introduce shared timeout helpers for retrieving scoped configuration and wrapping blocking calls
- add infrastructure-level tests covering success, retry fallback, and metadata override scenarios while updating the provider integration checklist

## Testing
- python -m compileall src/infrastructure/preflight src/infrastructure/timeouts.py tests/infrastructure/preflight/test_openai_gateway.py
- pytest tests/infrastructure/preflight/test_openai_gateway.py

------
https://chatgpt.com/codex/tasks/task_e_68cf9e1b59888326bb1c957b9226b875